### PR TITLE
[REF] sipreco_purchase: Change the logic to restring routes

### DIFF
--- a/sipreco_purchase/__manifest__.py
+++ b/sipreco_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Sipreco Purchase Management',
-    'version': '11.0.1.11.0',
+    'version': '11.0.1.12.0',
     'license': 'AGPL-3',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',

--- a/sipreco_purchase/models/purchase_requisition.py
+++ b/sipreco_purchase/models/purchase_requisition.py
@@ -65,8 +65,20 @@ class PurchaseRequisition(models.Model):
 
     route_id = fields.Many2one(
         'stock.location.route',
-        ondelete='restrict',
     )
+
+    route_ids = fields.Many2many(
+        'stock.location.route',
+        compute='_compute_route_ids',
+        readonly=True,
+    )
+
+    @api.depends('user_id')
+    def _compute_route_ids(self):
+        for rec in self:
+            user_picking_type_ids = self.env.user.picking_type_ids.ids
+            rec.route_ids = self.env['stock.location.route'].search(
+                [('pull_ids.picking_type_id', 'in', user_picking_type_ids)])
 
     @api.depends('line_ids')
     def _compute_amount_total(self):

--- a/sipreco_purchase/security/sipreco_purchase_security.xml
+++ b/sipreco_purchase/security/sipreco_purchase_security.xml
@@ -94,28 +94,15 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
-    <record model="ir.rule" id="route_only_read_rule">
-        <field name="name">Route only read</field>
-        <field name="model_id" ref="stock.model_stock_location_route"/>
-        <field name="groups" eval="[(4, ref('stock.group_stock_user'))]"/>
-        <field name="domain_force">[('pull_ids.picking_type_id', 'in', user.picking_type_ids.ids)]</field>
-    </record>
-
     <record model="ir.rule" id="requisition_only_read_rule">
         <field name="name">Requisition only see if are in route allowed to user</field>
         <field name="model_id" ref="purchase_requisition.model_purchase_requisition"/>
         <field name="groups" eval="[(4, ref('stock.group_stock_user'))]"/>
         <field name="domain_force">['|', ('route_id', '=', False),('route_id.pull_ids.picking_type_id', 'in', user.picking_type_ids.ids)]</field>
     </record>
-    <record model="ir.rule" id="route_all_rule">
-        <field name="name">Route only read</field>
-        <field name="model_id" ref="stock.model_stock_location_route"/>
-        <field name="groups" eval="[(4, ref('purchase.group_purchase_user'))]"/>
-        <field name="domain_force">[(1 ,'=', 1)]</field>
-    </record>
 
     <record model="ir.rule" id="requisition_all_rule">
-        <field name="name">Requisition only see if are in route allowed to user</field>
+        <field name="name">Requisition All</field>
         <field name="model_id" ref="purchase_requisition.model_purchase_requisition"/>
         <field name="groups" eval="[(4, ref('purchase.group_purchase_user'))]"/>
         <field name="domain_force">[(1 ,'=', 1)]</field>

--- a/sipreco_purchase/views/purchase_requisition_views.xml
+++ b/sipreco_purchase/views/purchase_requisition_views.xml
@@ -82,7 +82,8 @@
             <field name="vendor_id" position="after">
                 <field name="expedient_id" attrs="{'readonly': [('state', '=', 'done')]}"/>
                 <field name="transaction_type_id" readonly="1"/>
-                <field name="route_id"/>
+                <field name="route_ids" invisible="1"/>
+                <field name="route_id" domain="[('id', 'in', route_ids)]"/>
                 <field name="inspected" readonly="1"/>
                 <field name="user_inspected_id" readonly="1"/>
                 <field name="user_confirmed_id" readonly="1"/>


### PR DESCRIPTION
Insted to use rules, use compute fields to get the ids of the routes that the user can access. Becase we only want to restring the routes in the requisition not in all models