### PR TITLE
[IMP] public_budget: Invoice cancel

### DIFF
--- a/public_budget/__manifest__.py
+++ b/public_budget/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': 'Public Budget',
     'license': 'AGPL-3',
-    'version': '11.0.1.25.0',
+    'version': '11.0.1.26.0',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',
     'category': 'Accounting & Finance',
@@ -34,6 +34,9 @@
         'report_extended_payment_group',
         # usado por algunos reportes como el de cheques y retenciones
         'l10n_ar_aeroo_base',
+        # Para poder habilitar el cancel_invoice en estado hecho para todos los
+        # users sin modo desarrollador
+        'account_ux',
     ],
     'data': [
         'security/public_budget_group.xml',

--- a/public_budget/views/account_invoice_views.xml
+++ b/public_budget/views/account_invoice_views.xml
@@ -67,4 +67,16 @@
         </field>
     </record>
 
+
+    <record id="invoice_supplier_form_ux" model="ir.ui.view">
+        <field name="name">account.invoice.form</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account_ux.invoice_supplier_form"/>
+        <field name="arch" type="xml">
+            <button name="invoice_cancel_from_done" position="attributes">
+                <attribute name="groups">account.group_account_user</attribute>
+            </button>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
From an invoice who has validated and paid, the module account_ux incorporate an button to cancel in that state, but it's only visible with developer mode. For sipreco we need this button visible for the account user group.