### PR TITLE
[FIX] public_budget: Fix in budget position analysis view

### DIFF
--- a/public_budget/__manifest__.py
+++ b/public_budget/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': 'Public Budget',
     'license': 'AGPL-3',
-    'version': '11.0.1.28.0',
+    'version': '11.0.1.29.0',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',
     'category': 'Accounting & Finance',

--- a/public_budget/views/budget_views.xml
+++ b/public_budget/views/budget_views.xml
@@ -37,7 +37,7 @@
                         <button name="action_to_open_modification" icon="fa-list-alt" type="object" class="oe_stat_button" groups="account.group_account_user">
                             <span class="o_stat_text">Budget Modification Detail</span>
                         </button>
-                        <button class="oe_stat_button" icon="fa-bars" name="%(action_position_analysis_tree)d" string="Position analysis" type="action" widget="statinfo" context="{'budget_id':active_id}"/>
+                        <button class="oe_stat_button" icon="fa-bars" name="%(action_position_analysis_tree)d" string="Position analysis" type="action" widget="statinfo" context="{'budget_id':id}"/>
                         <button name="action_to_open_definitive_lines" icon="fa-bars" type="object" class="oe_stat_button" attrs="{'invisible': [('state', '!=', 'pre_closed')]}" string="Budget Definitive Lines"/>
                     </div>
                     <group>


### PR DESCRIPTION
Only occurs in the budget to date when you visualize and try to analice the budget position with the button.
The values that you see are in zero, this is because the "active_id" that use in the context of button (to set what budget is from) it was not the budget "ID" it was the wizard "ID".