### PR TITLE
[FIX] public_budget: Fix an error in wizard generate invoices

### DIFF
--- a/public_budget/wizards/transaction_definitive_make_invoice.py
+++ b/public_budget/wizards/transaction_definitive_make_invoice.py
@@ -193,7 +193,8 @@ class PublicBudgetDefinitiveMakeInvoice(models.TransientModel):
             # Check advance remaining amount
             advance_to_return_amount = (
                 self.transaction_id.advance_to_return_amount)
-            if self.to_invoice_amount > advance_to_return_amount:
+            if self.currency_id.compare_amounts(
+                    self.to_invoice_amount, advance_to_return_amount) == 1:
                 raise ValidationError(_(
                     "You can not invoice more than Advance Remaining Amount!\n"
                     "* Amount to invoice: %s\n"


### PR DESCRIPTION
In some cases when consulting the value of the calculated field, it comes with many digits and if we calculate it directly no. For that reason we are consulting it directly without using the computed field.