### PR TITLE
[FIX] public_budget: changes in views of expedients & remits

### DIFF
--- a/public_budget/__manifest__.py
+++ b/public_budget/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': 'Public Budget',
     'license': 'AGPL-3',
-    'version': '11.0.1.31.0',
+    'version': '11.0.1.32.0',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',
     'category': 'Accounting & Finance',

--- a/public_budget/security/ir.model.access.csv
+++ b/public_budget/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_public_budget_expedient_employee,public_budget_expedient.employee,model_public_budget_expedient,base.group_user,1,1,1,1
+access_public_budget_expedient_employee,public_budget_expedient.employee,model_public_budget_expedient,base.group_user,1,1,1,0
 access_public_budget_expedient_founder_all,public_budget_expedient_founder.all,model_public_budget_expedient_founder,,1,0,0,0
 access_public_budget_expedient_category_all,public_budget_expedient_category.all,model_public_budget_expedient_category,,1,0,0,0
 access_public_budget_remit_employee,public_budget_remit.employee,model_public_budget_remit,base.group_user,1,1,1,1

--- a/public_budget/views/expedient_views.xml
+++ b/public_budget/views/expedient_views.xml
@@ -33,7 +33,7 @@
         <field name="name">public_budget.expedient.form</field>
         <field name="model">public_budget.expedient</field>
         <field name="arch" type="xml">
-            <form string="Expedient">
+            <form string="Expedient" create="false" edit="false">
                 <header>
                     <button name="%(action_aeroo_report_expedient)d" class="oe_highlight" string="Print" type="action"/>
                     <button name="action_cancel_open" type="object" states="cancel" string="To Draft"/>
@@ -114,12 +114,26 @@
         </field>
     </record>
 
+
+    <record id="view_public_budget_expedient_form2" model="ir.ui.view">
+        <field name="name">public_budget.expedient.form.inherit</field>
+        <field name="model">public_budget.expedient</field>
+        <field name="inherit_id" ref="view_public_budget_expedient_form"/>
+        <field name="groups_id" eval="[(4, ref('group_portal_expedient')),(4, ref('group_secretary_usuario')),(4, ref('account.group_account_user')),(4, ref('group_habilitacion_usuario'))]"/>
+        <field name="arch" type="xml">
+            <form position="attributes">
+                <attribute name="create">true</attribute>
+                <attribute name="edit">true</attribute>
+            </form>
+        </field>
+    </record>
+
     <!-- TREEVIEW -->
     <record id="view_public_budget_expedient_tree" model="ir.ui.view">
         <field name="name">public_budget.expedient.tree</field>
         <field name="model">public_budget.expedient</field>
         <field name="arch" type="xml">
-            <tree string="Expedient" decoration-muted="state=='cancelled'" decoration-info="state == 'open'" decoration-bf="state in ['annulled', 'closed']" decoration-danger="state in ()">
+            <tree string="Expedient" decoration-muted="state=='cancelled'" decoration-info="state == 'open'" decoration-bf="state in ['annulled', 'closed']" decoration-danger="state in ()" create="false" edit="false">
                 <field name="number"/>
                 <field name="issue_date"/>
                 <field name="cover"/>
@@ -135,6 +149,19 @@
                 <field name="subsidy_approved"/>
                 <field name="overdue"/>
                 <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_public_budget_expedient_tree2" model="ir.ui.view">
+        <field name="name">public_budget.expedient.tree.inherit</field>
+        <field name="model">public_budget.expedient</field>
+        <field name="inherit_id" ref="view_public_budget_expedient_tree"/>
+        <field name="groups_id" eval="[(4, ref('group_portal_expedient')),(4, ref('group_secretary_usuario')),(4, ref('account.group_account_user')),(4, ref('group_habilitacion_usuario'))]"/>
+        <field name="arch" type="xml">
+            <tree position="attributes">
+                <attribute name="create">true</attribute>
+                <attribute name="edit">true</attribute>
             </tree>
         </field>
     </record>

--- a/public_budget/views/remit_views.xml
+++ b/public_budget/views/remit_views.xml
@@ -67,9 +67,26 @@
                         <field name="confirmation_date"/> 
                     </group>
                  </group>
-                <field name="expedient_ids"
-                    domain="[('current_location_id','=',location_id),('in_transit','=',False)]" options="{'no_create': True}"
-                /> 
+                    <field name="expedient_ids"
+                        domain="[('current_location_id','=',location_id),('in_transit','=',False)]" options="{'no_create': True}">
+                        <tree string="Expedient" decoration-muted="state=='cancelled'" decoration-info="state == 'open'" decoration-bf="state in ['annulled', 'closed']" decoration-danger="state in ()">
+                            <field name="number"/>
+                            <field name="issue_date"/>
+                            <field name="cover"/>
+                            <field name="reference"/>
+                            <field name="last_move_date"/>
+                            <field name="founder_id"/>
+                            <field name="category_id"/>
+                            <field name="type"/>
+                            <field name="current_location_id"/>
+                            <field name="in_transit"/>
+                            <field name="pages"/>
+                            <field name="user_id"/>
+                            <field name="subsidy_approved"/>
+                            <field name="overdue"/>
+                            <field name="state"/>
+                        </tree>
+                    </field>
                 </sheet>
 
             </form>


### PR DESCRIPTION
Becase a problem explanned in this commit https://github.com/ingadhoc/odoo-public-administration/commit/79de609e7ca48ec49d31c28fa5a017db3b4ef75d.
And the restriction to some user to crate expedient if there not in groups (secretary, habilitacion and account). we modify this by inherit groups view