### PR TITLE
[FIX] public_budget: miss budget in context

### DIFF
--- a/public_budget/__manifest__.py
+++ b/public_budget/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': 'Public Budget',
     'license': 'AGPL-3',
-    'version': '11.0.1.33.0',
+    'version': '11.0.1.34.0',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',
     'category': 'Accounting & Finance',

--- a/public_budget/views/budget_views.xml
+++ b/public_budget/views/budget_views.xml
@@ -61,10 +61,10 @@
                             <field name="parent_budget_position_ids" context="{'budget_id':active_id, 'tree_view_ref': 'public_budget.view_budget_position_budget_tree'}"/>
                         </page>
                         <page string="Detail">
-                            <field name="budget_detail_ids"/>
+                            <field name="budget_detail_ids" context="{'budget_id':active_id}"/>
                         </page>
                         <page string="Moves">
-                            <field name="budget_modification_ids"/>
+                            <field name="budget_modification_ids" context="{'budget_id':active_id}"/>
                         </page>
                         <page string="Funding Moves">
                             <field name="funding_move_ids"/>


### PR DESCRIPTION
To avoid a problem when add lines to a budget, that calculate the all of values, becase the "Budget_id" was not in the context.