### PR TITLE
[FIX] sipreco_purchase: access error to expedient

### DIFF
--- a/sipreco_purchase/__manifest__.py
+++ b/sipreco_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Sipreco Purchase Management',
-    'version': '11.0.1.17.0',
+    'version': '11.0.1.18.0',
     'license': 'AGPL-3',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',

--- a/sipreco_purchase/views/expedient_views.xml
+++ b/sipreco_purchase/views/expedient_views.xml
@@ -5,10 +5,11 @@
         <field name="name">sipreco_purchase.expedient.form</field>
         <field name="model">public_budget.expedient</field>
         <field name="inherit_id" ref="public_budget.view_public_budget_expedient_form"/>
+        <field name="groups_id" eval="[(4, ref('sipreco_purchase.group_only_read_purchase_order_requisition')),(4, ref('sipreco_purchase.group_requester_employee'))]"/>
         <field name="arch" type="xml">
             <div name="button_box">
                 <field name="purchase_order_ids" invisible="1"/>
-                <button class="oe_stat_button" name="%(purchase.purchase_form_action)d" type="action" string="Purchase Orders" groups="sipreco_purchase.group_only_read_purchase_order_requisition,sipreco_purchase.group_requester_employee" context="{'search_default_expedient_id': active_id}" icon="fa-credit-card" attrs="{'invisible':[('purchase_order_ids', '=', False)]}"/>
+                <button class="oe_stat_button" name="%(purchase.purchase_form_action)d" type="action" string="Purchase Orders" context="{'search_default_expedient_id': active_id}" icon="fa-credit-card" attrs="{'invisible':[('purchase_order_ids', '=', [])]}"/>
             </div>
         </field>
     </record>


### PR DESCRIPTION
To avoid this issue when the user hasn't the allow to see the POs, only charge the view if the user has in that group(purchase user o purchase viewer).