### PR TITLE
[11.0] [FIX] sipreco_purchase: change the group in expedient view

### DIFF
--- a/sipreco_purchase/__manifest__.py
+++ b/sipreco_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Sipreco Purchase Management',
-    'version': '11.0.1.18.0',
+    'version': '11.0.1.19.0',
     'license': 'AGPL-3',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',

--- a/sipreco_purchase/views/expedient_views.xml
+++ b/sipreco_purchase/views/expedient_views.xml
@@ -5,7 +5,7 @@
         <field name="name">sipreco_purchase.expedient.form</field>
         <field name="model">public_budget.expedient</field>
         <field name="inherit_id" ref="public_budget.view_public_budget_expedient_form"/>
-        <field name="groups_id" eval="[(4, ref('sipreco_purchase.group_only_read_purchase_order_requisition')),(4, ref('sipreco_purchase.group_requester_employee'))]"/>
+        <field name="groups_id" eval="[(4, ref('sipreco_purchase.group_only_read_purchase_order_requisition')),(4, ref('stock.group_stock_user'))]"/>
         <field name="arch" type="xml">
             <div name="button_box">
                 <field name="purchase_order_ids" invisible="1"/>


### PR DESCRIPTION
Use the group "solicitante" bacause the prevois group hasn't got the access to purchase order. Only need to show the button if the user has the purchase access.