### PR TITLE
[13.0] [PORT] sipreco_subsidy_management: from 11.0

### DIFF
--- a/public_budget/__manifest__.py
+++ b/public_budget/__manifest__.py
@@ -116,7 +116,6 @@
         'data/position_exc_restrictions.xml',
         'data/ir_config_parameter_data.xml',
         'data/server_actions_data.xml',
-        'data/certificado_de_retencion_report_data.xml',
     ],
     'demo': [
         'demo/res_company_demo.xml',

--- a/public_budget/data/certificado_de_retencion_report_data.xml
+++ b/public_budget/data/certificado_de_retencion_report_data.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-
-<record id="l10n_ar_account_withholding.action_aeroo_certificado_de_retencion_report" model="ir.actions.report">
-    <field name="process_sep" eval="True"/>
-</record>
-
-</odoo>

--- a/public_budget/models/account_payment_group.py
+++ b/public_budget/models/account_payment_group.py
@@ -470,5 +470,5 @@ class AccountPaymentGroup(models.Model):
         if not payments:
             return False
         return self.env['ir.actions.report'].search(
-            [('report_name', '=', 'certificado_de_retencion_report')],
+            [('report_name', '=', 'l10n_ar_account_withholding.report_withholding_certificate')],
             limit=1).report_action(payments)

--- a/public_budget/views/account_payment_views.xml
+++ b/public_budget/views/account_payment_views.xml
@@ -106,7 +106,7 @@
                 <button name="change_withholding" icon="fa-undo" type="object" attrs="{'invisible': ['|', '|', ('payment_type', '!=', 'outbound'), ('state', '!=', 'posted'), ('payment_method_code', '!=', 'withholding')]}" confirm="Seguro que desea devolver esta retención?"/>
                 <field name="payment_type" invisible="1"/>
             </tree>
-            <button name="%(l10n_ar_account_withholding.action_aeroo_certificado_de_retencion_report)d" position="attributes">
+            <button name="%(l10n_ar_account_withholding.action_report_withholding_certificate)d" position="attributes">
                 <attribute name="invisible">1</attribute>
             </button>
         </field>

--- a/sipreco_subsidy_management/__manifest__.py
+++ b/sipreco_subsidy_management/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Public Budget Subsidy Management',
-    'version': '13.0.1.0.0',
+    'version': '13.0.1.1.0',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',
     'category': 'Accounting & Finance',

--- a/sipreco_subsidy_management/i18n/es.po
+++ b/sipreco_subsidy_management/i18n/es.po
@@ -152,6 +152,11 @@ msgid "Cambiar Estado"
 msgstr "Cambiar Estado"
 
 #. module: sipreco_subsidy_management
+#: selection:public_budget.subsidy.resolution,state:0
+msgid "Canceled"
+msgstr "Cancelado"
+
+#. module: sipreco_subsidy_management
 #: model:ir.model.fields,field_description:sipreco_subsidy_management.field_public_budget_subsidy_cargo_amount
 msgid "Cargos"
 msgstr "Cargos"

--- a/sipreco_subsidy_management/models/subsidy_resolution.py
+++ b/sipreco_subsidy_management/models/subsidy_resolution.py
@@ -22,9 +22,10 @@ class PublicBudgetSubsidyResolution(models.Model):
     )
     state = fields.Selection([
         ('not_presented', 'Not Presented'),
-        ('presented', 'Presented')],
+        ('presented', 'Presented'),
+        ('canceled', 'Canceled')],
         'State',
-        default='not_presented'
+        default='not_presented',
     )
     subsidy_resolution_line_ids = fields.One2many(
         'public_budget.subsidy.resolution.line',
@@ -55,6 +56,10 @@ class PublicBudgetSubsidyResolution(models.Model):
                 rec.state = 'presented'
             elif rec.state == 'presented':
                 rec.state = 'not_presented'
+
+    def cancel(self):
+        for rec in self:
+            rec.state = 'canceled'
 
     @api.constrains('state')
     def _validate_state_presented(self):

--- a/sipreco_subsidy_management/views/subsidy_resolution_views.xml
+++ b/sipreco_subsidy_management/views/subsidy_resolution_views.xml
@@ -11,7 +11,8 @@
                 <header>
                     <button type="object" string="Cambiar Estado" name="action_change_state"/>
                     <button type="object" string="Generar Remito" name="generate_remit"/>
-                    <field name="state" widget="statusbar" clickable="true"/>
+                    <button type="object" string="Cancelar" name="cancel" states="not_presented,presented" groups="base.group_no_one"/>
+                    <field name="state" widget="statusbar"/>
                 </header>
                 <sheet string="Resolucion Subsidios">
                     <group>


### PR DESCRIPTION
[11.0] [IMP] sipreco_subsidy_management: new state and button to control resolutions

Add new estate to cancel resolution, also new botton to go to review a resolution.
Constrain to not be able to go to presented if the review boolean is true.