### PR TITLE
[13.0] [PORT] from 11.0

### DIFF
--- a/sipreco_subsidy_management/models/subsidy_resolution_line.py
+++ b/sipreco_subsidy_management/models/subsidy_resolution_line.py
@@ -43,6 +43,8 @@ class PublicBudgetSubsidyResolutionLines(models.Model):
         self.partner_id = self.expedient_id.employee_subsidy_requestor
         self.name = self.expedient_id.cover
         self.dni = self.expedient_id.subsidy_recipient_doc
+        if self.expedient_id.subsidy_amount:
+            self.amount = self.expedient_id.subsidy_amount
         resolutions_with_expedient = self.search(
             [('expedient_id', '=', self.expedient_id.id)])
         if len(resolutions_with_expedient) > 0:


### PR DESCRIPTION
[11.0] [FIX] sipreco_subsidy_management: use the expedient value in resolution line

Add to the onchange in resolution line when change expediente, set the amount on the expediente in the amount of the resolution line.