### PR TITLE
[13.0] [FIX] public_budget: Cancel and delete vendor bills.

### DIFF
--- a/public_budget/models/definitive_line.py
+++ b/public_budget/models/definitive_line.py
@@ -137,6 +137,7 @@ class DefinitiveLine(models.Model):
 
     @api.depends(
         'invoice_line_ids.move_id.state',
+        'invoice_line_ids.move_id.invoice_payment_state',
         'invoice_line_ids.move_id.to_pay_amount',
         'invoice_line_ids.move_id.amount_residual',
     )
@@ -157,6 +158,7 @@ class DefinitiveLine(models.Model):
 
     @api.depends(
         'invoice_line_ids.move_id.state',
+        'invoice_line_ids.move_id.invoice_payment_state',
         'invoice_line_ids.move_id.to_pay_amount',
         'invoice_line_ids.move_id.amount_residual',
     )

--- a/public_budget/views/account_move_views.xml
+++ b/public_budget/views/account_move_views.xml
@@ -26,9 +26,6 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account_ux.view_move_form"/>
         <field name="arch" type="xml">
-            <!-- <button name="button_cancel" position="attributes">
-                <attribute name="groups">account.group_account_user</attribute>
-            </button> -->
             <button name="delete_number" position="attributes">
                 <attribute name="groups">account.group_account_user</attribute>
             </button>


### PR DESCRIPTION
Ticket 31024

Fix the name of the inherit method to cancel bills.
Adapt to sipreco to delete bills when you don't use documents.