### PR TITLE
[13.0] [FIX] public_budget: Validate advance return with the same name of entry

### DIFF
--- a/public_budget/models/advance_return.py
+++ b/public_budget/models/advance_return.py
@@ -93,7 +93,6 @@ class AdvanceReturn(models.Model):
                 'name': self.name,
             }))
         journal = self.type_id.return_journal_id
-        ref = journal.sequence_id._next()
         lines_vals.append(
             (0, 0, {
                 'partner_id': return_partner.id,
@@ -105,8 +104,7 @@ class AdvanceReturn(models.Model):
 
         return {
             'line_ids': lines_vals,
-            'ref': ref,
-            'name': self.name,
+            'ref': self.name,
             'journal_id': journal.id,
         }
 

--- a/public_budget/models/advance_return.py
+++ b/public_budget/models/advance_return.py
@@ -150,8 +150,6 @@ class AdvanceReturn(models.Model):
     def action_cancel_draft(self):
         """ go from canceled state to draft state"""
         self.write({'state': 'draft'})
-        self.delete_workflow()
-        self.create_workflow()
         return True
 
     def unlink(self):


### PR DESCRIPTION
The problem occurs when wanting to use the same name of the advance for the entry name, as the name of the advance is repeated, there is already a generated entry with that name. Odoo restrict duplicated name of entry for same journal and type.
What we do is use the ref as part of the name and we do not complete the ref field since the display name already completes it and we would be repeating the same number.

**Ticket Nbr: 31868**