### PR TITLE
[13.0] [IMP] sipreco_purchase: Changes in the workflow of requisition.

### DIFF
--- a/sipreco_purchase/__manifest__.py
+++ b/sipreco_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Sipreco Purchase Management',
-    'version': '13.0.1.2.0',
+    'version': '13.0.1.3.0',
     'license': 'AGPL-3',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',

--- a/sipreco_purchase/models/purchase_requisition.py
+++ b/sipreco_purchase/models/purchase_requisition.py
@@ -12,7 +12,6 @@ class PurchaseRequisition(models.Model):
     name = fields.Char(
         # cambiamos string
         'Reference',
-        default = lambda x: x.env['ir.sequence'].next_by_code('purchase.requisition.purchase.tender') or 'New'
     )
     manual_request_ids = fields.One2many(
         'stock.request',
@@ -114,6 +113,9 @@ class PurchaseRequisition(models.Model):
     @api.model
     def create(self, vals):
         vals['date'] = fields.Date.today()
+        if 'name' in vals and vals['name'] == 'New':
+            vals['name'] = self.env['ir.sequence'].next_by_code(
+                'purchase.requisition.purchase.tender') or 'New'
         return super().create(vals)
 
     def action_in_progress(self):
@@ -130,3 +132,11 @@ class PurchaseRequisition(models.Model):
         if not self.printed:
             self.printed = True
         return action.read()[0]
+
+    def action_draft(self):
+        """ We need to keep the original number for the order regardless of change the state
+        """
+        self.ensure_one()
+        name = self.name
+        super().action_draft()
+        self.name = name

--- a/sipreco_purchase/views/purchase_requisition_views.xml
+++ b/sipreco_purchase/views/purchase_requisition_views.xml
@@ -58,7 +58,10 @@
             </div>
             <button name="%(purchase_requisition.action_purchase_requisition_to_so)d" position="after">
                 <button name="to_inspected" string="To Inspected" type="object" groups="purchase.group_purchase_user" attrs="{'invisible':['|', ('state', '!=', 'draft'),('inspected','=', True)]}"/>
-                <button name="action_draft" string="To Draft" type="object" groups="purchase.group_purchase_user" attrs="{'invisible':['|', ('state', 'not in', ['draft', 'in_progress']),('inspected','!=', True)]}"/>
+            </button>
+            <button name="action_draft" position="attributes">
+                <attribute name="groups">purchase.group_purchase_user</attribute>
+                <attribute name="attrs">{'invisible':['|', ('state', '!=', 'cancel'),('inspected','!=', True)]}</attribute>
             </button>
 
             <field name="product_id" position="after">
@@ -128,7 +131,7 @@
                 <attribute name="attrs">{'readonly': ['|',('state', '!=', 'draft'),('inspected', '=', True)]}</attribute>
             </field>
             <field name="name" position="attributes">
-                <attribute name="attrs">{'readonly': ['|',('state', '!=', 'draft'),('inspected', '=', True)]}</attribute>
+                <attribute name="attrs">{'readonly': ['|',('name', '!=', 'New'),('inspected', '=', True)]}</attribute>
             </field>
             <field name="company_id" position="attributes">
                 <attribute name="attrs">{'readonly': ['|',('state', '!=', 'draft'),('inspected', '=', True)]}</attribute>


### PR DESCRIPTION
* For the creation of the requisition set the number when create not by default in the view.
* If you set to draft the order keep the number when change the state
* Use the button to set to draft by odoo and adding the attributes for sipreco.