### PR TITLE
[FIX] sipreco_project: invalid license value

### DIFF
--- a/sipreco_project/__manifest__.py
+++ b/sipreco_project/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Sipreco Project',
-    'license': ' LGPL-3',
+    'license': 'LGPL-3',
     'version': '13.0.1.0.0',
     'category': 'Accounting',
     'sequence': 14,


### PR DESCRIPTION
Remove extra white space in the license value because Odoo is not letting to run the server the module load registry is failing (even if we are not installing this module).

![image (17)](https://user-images.githubusercontent.com/7593953/147596759-ceb26465-f156-4408-af52-0eb82fbda83c.png)
