### PR TITLE
[FIX] public_budget: anular cheque

### DIFF
--- a/public_budget/models/account_payment.py
+++ b/public_budget/models/account_payment.py
@@ -159,8 +159,6 @@ class AccountPayment(models.Model):
             # 'tree_view_ref': (
             #     'account_payment_group.'
             #     'view_account_payment_from_group_tree'),
-            'default_receiptbook_id': self.receiptbook_id.id,
-            'default_document_number': self.document_number,
             'default_payment_group_id': self.payment_group_id.id,
             'replaced_payment_id': self.id,
         }


### PR DESCRIPTION
Ticket: 58181
Elimino default_receiptbook_id y default_document_number del context para crear el pago porque los campos receiptbook_id y document_number no se usan en ninguna vista del payment
    
'account.payment' object has no attribute 'receiptbook_id'