### PR TITLE
[FIX] public_budget:

### DIFF
--- a/public_budget/models/account_move.py
+++ b/public_budget/models/account_move.py
@@ -188,3 +188,9 @@ class AccountMove(models.Model):
         self.filtered(lambda x: x.move_type in x.get_purchase_types() and x.state in (
             'draft', 'cancel') and not x.l10n_latam_use_documents).write({'name': '/'})
         return super().unlink()
+
+    @api.model
+    def _deduce_sequence_number_reset(self, name):
+        if self.env.context.get("from_payment_group"):
+            return 'never'
+        return super()._deduce_sequence_number_reset(name)

--- a/public_budget/models/account_payment_group.py
+++ b/public_budget/models/account_payment_group.py
@@ -147,6 +147,7 @@ class AccountPaymentGroup(models.Model):
                 'tax_line_id')
 
     def post(self):
+        self = self.with_context(from_payment_group=True)
         for rec in self:
             # si no estaba seteada la setamos
             if not rec.payment_date:


### PR DESCRIPTION
Actualmente a dia de hoy es año 2023 si intentamos validar un pago de proveedor de 2022 intenta validar un account.move.line y traslatar el name o secuencia que esta en el grupo pago que es 2022. Esto da error porque de lado de odoo hay un constraint que si el asiento es validado a hoy tiene fecha 2023 y no coincide con el año que estamos colocando como nomnre/secuencia del aml.

Debido a que aca no importa realmente el nombre del aml, agregamos este workaroung para evitar el error, al menos por los momentos.