### PR TITLE
[IMP] public_budget: modificar nro de folios en expediente

### DIFF
--- a/public_budget/models/expedient.py
+++ b/public_budget/models/expedient.py
@@ -220,10 +220,13 @@ class PublicBudgetExpedient(models.Model):
         if 'pages' in vals:
             new_pages = vals.get('pages')
             for record in self:
-                if new_pages < record.pages:
-                    raise ValidationError(_('No puede disminuir la cantidad '
-                                            'de páginas de un '
-                                            'expediente'))
+                admin_users = self.env['res.users'].sudo().search([('groups_id', 'in', [self.env.ref('base.group_system').id])])
+                if new_pages and self.env.user in admin_users and self.user_has_groups('base.group_no_one'):
+                    message = _("Cantidad de páginas modificadas de %d a %d") % (
+                    self.pages, new_pages)
+                    self.message_post(body=message)
+                else:
+                    raise ValidationError(_('No tiene autorización para modificar la cantidad de páginas de un expediente'))
         return super().write(vals)
 
     def check_expedients_exist(self):


### PR DESCRIPTION
Task: 28174
Ahora la cantidad de nro de folios en expedientes solo podrá ser modificada si se tiene permiso de administración y modo desarrollador activado.