### PR TITLE
[IMP] public_budget: modificar nro de folios en expediente

### DIFF
--- a/public_budget/models/expedient.py
+++ b/public_budget/models/expedient.py
@@ -221,11 +221,12 @@ class PublicBudgetExpedient(models.Model):
             new_pages = vals.get('pages')
             for record in self:
                 admin_users = self.env['res.users'].sudo().search([('groups_id', 'in', [self.env.ref('base.group_system').id])])
-                if new_pages != record.pages:
+                if new_pages < record.pages:
                     if not (self.env.user in admin_users and self.user_has_groups('base.group_no_one')):
                         raise ValidationError(_('No tiene autorización para modificar la cantidad de páginas de un expediente'))
-                    message = _("Cantidad de páginas modificadas de %d a %d") % (self.pages, new_pages)
-                    self.message_post(body=message)
+                if new_pages != record.pages:
+                    message = _("Cantidad de páginas modificadas de %d a %d") % (record.pages, new_pages)
+                    record.message_post(body=message)
         return super().write(vals)
 
     def check_expedients_exist(self):


### PR DESCRIPTION
Task: 28174
Ahora la cantidad de nro de folios en expedientes solo podrá ser modificada si se tiene permiso de administración y modo desarrollador activado.