### PR TITLE
[IMP] sipreco_payment_line: eliminar masivamente líneas de transferencia

### DIFF
--- a/sipreco_payment_line/__manifest__.py
+++ b/sipreco_payment_line/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Sipreco Payment Lines',
-    'version': "15.0.1.0.0",
+    'version': "15.0.1.1.0",
     'license': 'AGPL-3',
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',

--- a/sipreco_payment_line/models/account_payment_group.py
+++ b/sipreco_payment_line/models/account_payment_group.py
@@ -101,3 +101,8 @@ class AccountPaymentGroup(models.Model):
         self.archivo_banco = base64.encodestring(
             ('\r\n'.join(lines_data) + '\r\n').encode())
         self.archivo_banco_name = 'Archivo banco %s.txt' % fields.Date.today()
+
+    def remove_all_transfer_lines(self):
+        """ Botón usado dentro de una orden de pago en una transacción para que en la solapa 'Líneas de Transferencia' se pueda borrar masivamente todas las trasferencias cuando la orden de pago se encuentra en estado 'Borrador'. """
+        if self.state == 'draft':
+            self.line_ids = False

--- a/sipreco_payment_line/views/account_payment_group_views.xml
+++ b/sipreco_payment_line/views/account_payment_group_views.xml
@@ -30,6 +30,7 @@
                     </group>
                     <button type="action" name="%(sipreco_payment_line.action_account_payment_line_import)d" string="Importar"/>
                     <button type="object" name="check_payment_lines_total" string="Verificar Total"/>
+                    <button name="remove_all_transfer_lines" string="Eliminar todo" states="draft" type="object"/>
                     <field name="line_ids">
                         <tree editable="bottom">
                             <field name="partner_id"/>


### PR DESCRIPTION
Tarea: 30616
Botón usado dentro de una orden de pago en una transacción para que en la solapa 'Líneas de Transferencia' se pueda borrar masivamente todas las trasferencias cuando la orden de pago se encuentra en estado 'Borrador'.