### PR TITLE
[IMP] public_budget: evitar preselección de proveedor al crear comprobante desde transacción

### DIFF
--- a/public_budget/wizards/transaction_definitive_make_invoice.py
+++ b/public_budget/wizards/transaction_definitive_make_invoice.py
@@ -128,12 +128,6 @@ class PublicBudgetDefinitiveMakeInvoice(models.TransientModel):
             rec.available_journal_document_type_ids = move.l10n_latam_available_document_type_ids
             rec.journal_document_type_id = move.l10n_latam_document_type_id
 
-    @api.onchange('supplier_ids')
-    def _onchange_supplier_id(self):
-        for rec in self:
-            if not rec.supplier_id and len(rec.supplier_ids) == 1:
-                rec.supplier_id = rec.supplier_ids.id
-
     @api.depends('transaction_id')
     def _compute_supplier_ids(self):
         for rec in self:


### PR DESCRIPTION
Tarea: 39415
En una transacción cuando se carga una afectación definitiva con un solo proveedor, luego al crear un comprobante se preselecciona y no se visualizan automáticamente las afectaciones definitivas. Lo que hace este pr es que no se preseleccione automáticamente el proveedor. De esta manera lo elige el usuario y luego automáticamente se cargan las afectaciones definitivas. Este commit cumple con el comportamiento esperado de de este video: https://drive.google.com/file/d/1qQz94fc0nvBqbBbSUky02f2zbViZyp4E/view?pli=1