### PR TITLE
[FIX] public_budget: remove class oe_read_only from transaction view

### DIFF
--- a/public_budget/__manifest__.py
+++ b/public_budget/__manifest__.py
@@ -1,16 +1,14 @@
 {
     'name': 'Public Budget',
     'license': 'AGPL-3',
-    'version': "18.0.1.0.0",
+    'version': "18.0.1.1.0",
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',
     'category': 'Accounting & Finance',
     'depends': [
-        #'web_m2x_options',
         'portal_backend',
         'sales_team',
         'account_accountant_ux',
-        # 'account_payment_group',
         'account_asset',
         'report_aeroo',
         # estrictamente solo requerido por algunos campos en vista de partner

--- a/public_budget/views/transaction_views.xml
+++ b/public_budget/views/transaction_views.xml
@@ -112,7 +112,7 @@
                             <field name="advance_payment_ids" context="{'default_transaction_id':id, 'default_partner_id': partner_id, 'default_partner_type': 'supplier'}" readonly="state == 'open'"/>
                         </page>
                         <page string="Invoices">
-                            <div class="oe_read_only">
+                            <div>
                                 <button class="oe_link" string="Create Invoice" invisible="state != 'open'" type="action" name="%(public_budget.action_definitive_make_invoice)d"/>
                                     or
                                 <button class="oe_link" string="Mass Invoice Create" invisible="state != 'open'" type="action" name="%(public_budget.action_definitive_mass_invoice_create)d"/>


### PR DESCRIPTION
task: 53988

- La clase no permitia ver correctamente los botones de crear factura y crear factura masiva.
- Eliminamos dependecias que ya no son necesarias.