### PR TITLE
[FIX] sipreco_payment_line: Adjust the pre-migration script

### DIFF
--- a/public_budget/migrations/18.0.1.0.0/post-migration.py
+++ b/public_budget/migrations/18.0.1.0.0/post-migration.py
@@ -3,12 +3,6 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-# def migrate_payment_grup_note(env):
-#     query = "select ap.id, notes from account_payment_group_bu apg join account_payment as ap on ap.payment_group_id_bu = apg.id where notes is not null"
-#     openupgrade.logged_query(env.cr, query)
-#     res = env.cr.fetchall()
-#     for payment_id, note in res:
-#         env['account.payment'].browse(payment_id).message_post(body='Nota migrada desde payment group version anterior: %s' % note)
 
 
 def migrate_payment_grup_data(env):
@@ -42,4 +36,3 @@ def migrate_payment_grup_data(env):
 def migrate(env, version):
     _logger.debug('Running migrate script for l10n_ar_withholding')
     migrate_payment_grup_data(env)
-    # migrate_payment_grup_note(env)

--- a/sipreco_payment_line/migrations/18.0.1.0.0/pre-migration.py
+++ b/sipreco_payment_line/migrations/18.0.1.0.0/pre-migration.py
@@ -10,29 +10,6 @@ def migrate(cr, version):
     - Update account.payment.group.line to point to the payment (set payment_id)
     """
 
-    # cr.execute("""
-    #     SELECT id, payment_group_id
-    #     FROM account_payment_group_line
-    #     WHERE payment_group_id IS NOT NULL
-    # """)
-    # lines = cr.fetchall()
-    # for line_id, payment_group_id in lines:
-    #     # Find first payment for this group
-    #     cr.execute("""
-    #         SELECT id FROM account_payment
-    #         WHERE payment_group_id_bu = %s
-    #         ORDER BY id ASC
-    #         LIMIT 1
-    #     """, (payment_group_id,))
-    #     payment = cr.fetchone()
-    #     if payment:
-    #         payment_id = payment[0]
-    #         # Update line to point to payment
-    #         cr.execute("""
-    #             UPDATE account_payment_group_line
-    #             SET payment_id = %s
-    #             WHERE id = %s
-    #         """, (payment_id, line_id))
     openupgrade.logged_query(
         cr,
         """


### PR DESCRIPTION
task: 54500

Movemos el pre migration ya que estaba mal ubicado y se ejecutaba en un modulo incorrecto.