### PR TITLE
[IMP] public_budget_tax_settlement: implementar txt de drei

### DIFF
--- a/public_budget_tax_settlement/__manifest__.py
+++ b/public_budget_tax_settlement/__manifest__.py
@@ -9,6 +9,7 @@
         'views/account_journal_dashboard_views.xml',
         'views/account_move_views.xml',
         'views/account_move_line_views.xml',
+        'data/drei_report.xml',
     ],
     'demo': [
     ],

--- a/public_budget_tax_settlement/data/drei_report.xml
+++ b/public_budget_tax_settlement/data/drei_report.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="l10n_ar_drei_report" model="account.report">
+        <field name="name">IIBB DREI (Agente)</field>
+        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="sequence">100</field>
+        <field name="country_id" ref="base.ar"/>
+        <field name="filter_hierarchy">never</field>
+        <field name="filter_unreconciled" eval="False"/>
+        <field name="filter_period_comparison" eval="False"/>
+        <field name="filter_growth_comparison" eval="False"/>
+        <field name="custom_handler_model_id" ref="model_l10n_ar_drei_report_handler"/>
+        <field name="column_ids">
+            <record id="l10n_ar_drei_report_column_total" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="name@es_419">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="l10n_ar_drei_report_withholdings_line" model="account.report.line">
+                <field name="name">Purchase Withholdings</field>
+                <!-- mejorar domain_formula para que busque por algo más sustentable que el nombre del grupo de impuestos -->
+                <field name="domain_formula">-sum([("tax_line_id.tax_group_id.name", "=", "Retención DreI"), ("tax_line_id.l10n_ar_state_id.country_id.code", "=", "AR"), ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier")])</field>
+            </record>
+        </field>
+    </record>
+
+    <record id="ar_drei_iibb_return_type" model="account.return.type">
+        <field name="name">DREI (Agente)</field>
+        <field name="report_id" ref="public_budget_tax_settlement.l10n_ar_drei_report"/>
+        <field name="default_deadline_periodicity">monthly</field>
+        <field name="auto_generate" eval="False"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="default_deadline_days_delay">5</field>
+        <field name="payment_partner_id" ref="l10n_ar.par_iibb_pagar"/>
+    </record>
+</odoo>

--- a/public_budget_tax_settlement/models/__init__.py
+++ b/public_budget_tax_settlement/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_move
 from . import account_move_line
+from . import drei_report

--- a/public_budget_tax_settlement/models/drei_report.py
+++ b/public_budget_tax_settlement/models/drei_report.py
@@ -1,0 +1,95 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class L10n_ArDreiReportHandler(models.AbstractModel):
+    _name = "l10n_ar.drei.report.handler"
+    _inherit = ["account.tax.report.handler"]
+    _description = "Argentinian DREI Report Custom Handler"
+
+    def _custom_options_initializer(self, report, options, previous_options):
+        super()._custom_options_initializer(report, options, previous_options=previous_options)
+
+        # Add export button
+        txt_export_button = [
+            {
+                "name": "TXT Retenciones DREI",
+                "sequence": 30,
+                "action": "export_file",
+                "action_param": "drei_ret_perc_txt",
+                "file_export_type": "TXT",
+                "branch_allowed": True,
+            },
+        ]
+        options["buttons"].extend(txt_export_button)
+
+    def drei_ret_perc_txt(self, options):
+        return {
+            "file_name": "DREI retenciones aplicadas.txt",
+            "file_content": self._drei_get_txt_files(options),
+            "file_type": "txt",
+        }
+
+    def _drei_get_txt_files(self, options):
+        """Returns DREI txt content"""
+        move_lines = self._drei_get_txt_lines(options)
+        return "".join(self._get_drei_txt_content(move_lines)).encode("ISO-8859-1", "ignore")
+
+    def get_standard_lines_domain(self, company_ids, options):
+        domain = [("company_id", "in", company_ids)]
+        state = options.get("all_entries") and "all" or "posted"
+        if state and state.lower() != "all":
+            domain += [("move_id.state", "=", state)]
+        if options.get("date").get("date_to"):
+            domain += [("date", "<=", options["date"]["date_to"])]
+        if options.get("date").get("date_from"):
+            domain += [("date", ">=", options["date"]["date_from"])]
+        return domain
+
+    def _drei_get_txt_lines(self, options):
+        state = options.get("all_entries") and "all" or "posted"
+        if state != "posted":
+            raise UserError(
+                _(
+                    "Can only generate TXT files using posted entries."
+                    " Please remove Include unposted entries filter and try again"
+                )
+            )
+        domain = [
+            ("tax_line_id.l10n_ar_state_id.country_id.code", "=", "AR"),
+            ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
+            # mejorar esto del domain para que no dependa del nombre del grupo de impuestos,
+            # sino de alguna característica más técnica
+            ("tax_line_id.tax_group_id.name", "=", "Retención DreI"),
+            ("payment_id", "!=", False),
+        ] + self.get_standard_lines_domain(self.env.company.ids, options)
+        return self.env["account.move.line"].search(domain, order="date asc, name asc, id asc")
+
+    def _get_drei_txt_content(self, move_lines):
+        """Implementado según especificación indicada en ticket 39347. También se puede ver detalles en readme"""
+        lines = []
+        for line in move_lines.sorted(key=lambda r: (r.date, r.id)):
+            content = ""
+            date = line.payment_id.date
+            # cuit (req): 11
+            content += line.partner_id.ensure_vat()
+            # razon_soc (req): 80
+            content += line.partner_id.name.ljust(80)[:80]
+            # nro_certificado: 10
+            content += "%010d" % int(line.withholding_id.name)
+            # fecha_ret: 10 (formato "dd/mm/aaaa")
+            content += fields.Date.from_string(date).strftime("%d/%m/%Y")
+            # base_imp: 09.2
+            content += "%012.2f" % line.withholding_id.base_amount
+            tax = line._get_settlement_tax() or line.tax_line_id
+            # alicuota: 09.6
+            content += f"{tax.amount:0>16.6f}"
+            # importe (req): 09.2
+            content += "%012.2f" % abs(line.amount_currency)
+
+            # new line
+            content += "\r\n"
+            lines.append(content)
+        return lines


### PR DESCRIPTION
Ticket: 112658
Es un FP manual que reemplaza a https://github.com/ingadhoc/odoo-argentina-ee/pull/986 , lo hacemos en public_budget_tax_settlement porque l10n_ar_account_tax_settlement no existe más en 19 y no lo queremos hacer en l10n_ar_account_reports porque "drei" solo lo usan spvh y cmr que usan sipreco.