### PR TITLE
[ADD] sipreco_purchase_web: publicación web de Solicitudes de Compra

### DIFF
--- a/sipreco_purchase/__manifest__.py
+++ b/sipreco_purchase/__manifest__.py
@@ -15,6 +15,7 @@
     'data': [
         'data/ir_actions_server_data.xml',
         'data/sequence_data.xml',
+        'data/mail_template_data.xml',
         'security/sipreco_purchase_security.xml',
         'security/hide_groups.xml',
         'security/ir.model.access.csv',

--- a/sipreco_purchase/data/mail_template_data.xml
+++ b/sipreco_purchase/data/mail_template_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="mail_template_purchase_requisition_imputada" model="mail.template">
+        <field name="name">SC Imputada - Notificación de imputación</field>
+        <field name="model_id" ref="purchase_requisition.model_purchase_requisition"/>
+        <field name="subject">SC {{ object.name }}{% if object.expedient_id %}, {{ object.expedient_id.name }}{% endif %} imputada</field>
+        <field name="body_html"><![CDATA[
+<p>Hola, la SC <strong>{{ object.name }}</strong>{% if object.expedient_id %}, <strong>{{ object.expedient_id.name }}</strong>{% endif %}, que solicita <strong>{{ object.description or '' }}</strong> se encuentra imputada. Se solicita informe proveedor apto para contratar.</p>
+        ]]></field>
+        <field name="lang">{{ object.user_id.lang }}</field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+
+</odoo>

--- a/sipreco_purchase/models/purchase_requisition.py
+++ b/sipreco_purchase/models/purchase_requisition.py
@@ -137,6 +137,30 @@ class PurchaseRequisition(models.Model):
             self.printed = True
         return action
 
+    def action_send_imputation_notice(self):
+        self.ensure_one()
+        template = self.env.ref(
+            'sipreco_purchase.mail_template_purchase_requisition_imputada',
+            raise_if_not_found=False,
+        )
+        ctx = {
+            'default_model': 'purchase.requisition',
+            'default_res_ids': self.ids,
+            'default_use_template': bool(template),
+            'default_template_id': template.id if template else False,
+            'default_composition_mode': 'comment',
+            'force_email': True,
+        }
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_model': 'mail.compose.message',
+            'views': [(False, 'form')],
+            'view_id': False,
+            'target': 'new',
+            'context': ctx,
+        }
+
     def action_draft(self):
         """ We need to keep the original number for the order regardless of change the state
         """

--- a/sipreco_purchase/views/purchase_requisition_views.xml
+++ b/sipreco_purchase/views/purchase_requisition_views.xml
@@ -32,6 +32,11 @@
             </button>
             <button name="action_cancel" position="after">
                 <button name="print_report_requisition" string="Print" type="object"/>
+                <button name="action_send_imputation_notice"
+                        string="Enviar notificación imputación"
+                        type="object"
+                        groups="purchase.group_purchase_user"
+                        invisible="state not in ('in_purchase', 'open', 'done')"/>
             </button>
 
             <button name="action_confirm" position="attributes">

--- a/sipreco_purchase_web/README.rst
+++ b/sipreco_purchase_web/README.rst
@@ -1,0 +1,161 @@
+==================================
+Sipreco Purchase Web Publication
+==================================
+
+Publicación web de Solicitudes de Compra: expone en el sitio web público las
+solicitudes de compra marcadas como publicables, con su documentación
+descargable, estado, fechas y adjudicatarios.
+
+Características
+===============
+
+- Marca de publicación web sobre la Solicitud de Compra (``purchase.requisition``):
+  campo "Publicable en web" y control de "Publicado en web".
+- Botones en el formulario de la Solicitud de Compra para **Publicar en web** y
+  **Despublicar**, más un botón de estadística **Ver Sitio Web** que abre la
+  ficha pública.
+- Solapa "Datos para página web" (visible solo si la solicitud es publicable)
+  con identificación pública, valor oficial (automático desde la SC o manual),
+  fechas, estado público con barra de estado clicable y observaciones.
+- Estado público independiente del estado interno: Para Apertura, En evaluación,
+  Adjudicada, Finalizada, Desierta, Fracasada, Suspendida.
+- Carga de archivos públicos por solicitud (pliegos, circulares, declaraciones
+  juradas u otros), con orden por secuencia.
+- Opción de exigir el ingreso de un email antes de permitir la descarga de un
+  archivo ("muro de email"), registrando cada descarga en un log.
+- Conteo de descargas por archivo y acceso al detalle de descargas registradas.
+- Registro de adjudicatarios con su valor adjudicado y cálculo automático del
+  valor total adjudicado.
+- Sitio web público en ``/compras`` con listado filtrable por estado, ficha de
+  detalle por solicitud y descarga de documentación.
+- Entrada de menú "Compras y Contrataciones" en el sitio web.
+- Actualización automática de la fecha de última actualización al modificar
+  datos públicos de una solicitud ya publicada.
+
+Detalles Técnicos
+=================
+
+**Modelos nuevos**
+
+- ``purchase.web.attachment`` — Archivo público de Solicitud de Compra.
+  Campos: ``sequence``, ``requisition_id`` (M2o a ``purchase.requisition``,
+  ondelete cascade), ``name``, ``attachment_type`` (pliego/circular/ddjj/other),
+  ``attachment`` (Binary) y ``attachment_fname``, ``require_email``,
+  ``download_log_ids`` (O2m), ``download_count`` (computado). Métodos:
+  ``_compute_download_count`` y ``action_view_download_logs``.
+- ``purchase.web.award`` — Adjudicatario de Solicitud de Compra. Campos:
+  ``requisition_id`` (M2o, ondelete cascade), ``partner_id`` (M2o a
+  ``res.partner``), ``amount`` (Monetary), ``currency_id`` (related a
+  ``requisition_id.currency_id``, store), ``notes``.
+- ``purchase.web.download.log`` — Log de descargas de archivos públicos. Campos:
+  ``attachment_line_id`` (M2o, ondelete cascade), ``requisition_id`` (related
+  store), ``email``, ``download_date`` (default now, readonly). Orden por
+  ``download_date desc``.
+
+**Modelos heredados**
+
+- ``purchase.requisition`` — se agregan campos de publicación web:
+  ``web_publishable``, ``website_published``, ``web_number``, ``web_object``,
+  ``web_amount``, ``web_amount_manual``, ``web_opening_datetime``,
+  ``web_publication_date``, ``web_last_update``, ``web_state``,
+  ``web_observations`` (Html), ``web_award_ids`` (O2m), ``web_total_awarded``
+  (Monetary computado, store), ``web_attachment_ids`` (O2m).
+  Lógica: ``_compute_web_total_awarded`` (depende de ``web_award_ids.amount``),
+  onchange ``_onchange_web_amount_manual`` y ``_onchange_web_publishable``,
+  override de ``write`` (sincroniza ``website_published`` y ``web_last_update``),
+  y acciones ``action_web_publish``, ``action_web_unpublish``,
+  ``action_view_website``.
+
+**Vistas incluidas**
+
+- Formulario de ``purchase.requisition`` heredado: botones de publicar/
+  despublicar, botón de estadística "Ver Sitio Web", campo "Publicable en web"
+  y solapa "Datos para página web" con sub-páginas de Archivos públicos y
+  Adjudicatarios.
+- Lista de ``purchase.requisition`` heredada con columnas de publicación.
+- Búsqueda de ``purchase.requisition`` heredada con filtros "Publicables en web"
+  y "Publicadas en web".
+- Formulario de ``purchase.web.attachment`` con botón de descargas.
+- Formulario de ``purchase.web.award``.
+- Lista de solo lectura de ``purchase.web.download.log`` y acción de ventana
+  ``action_purchase_web_download_log``.
+
+**Plantillas de sitio web (QWeb)**
+
+- ``purchase_list_template`` — listado público con filtros por estado.
+- ``purchase_detail_template`` — ficha de detalle de una solicitud.
+- ``purchase_email_gate_template`` — formulario de email previo a la descarga.
+
+**Controlador** (``controllers/main.py``, rutas públicas ``website=True``)
+
+- ``GET /compras`` — listado de solicitudes publicadas, filtrable por ``state``.
+- ``GET /compras/<id>`` — detalle de una solicitud publicada.
+- ``GET /compras/<id>/descargar/<attachment_line_id>`` — descarga de archivo;
+  si el archivo exige email, muestra el muro de email.
+- ``POST /compras/<id>/descargar/<attachment_line_id>/email`` — recepción del
+  email (con CSRF), validación básica y redirección a la descarga.
+
+**Seguridad**
+
+- ``ir.model.access.csv``: acceso completo para ``purchase.group_purchase_user``
+  sobre los tres modelos nuevos; lectura para ``base.group_public`` sobre
+  ``purchase.web.attachment`` y ``purchase.web.award``.
+- ``ir.rule`` ``purchase_requisition_public_rule``: el grupo público solo puede
+  leer solicitudes con ``website_published`` y ``web_publishable`` en ``True``.
+
+**Menú**
+
+- ``website.menu`` "Compras y Contrataciones" apuntando a ``/compras``.
+
+Uso
+===
+
+1. En una Solicitud de Compra (``purchase.requisition``), marcar el campo
+   **Publicable en web**.
+2. Completar la solapa **Datos para página web**: número, objeto, valor oficial
+   (automático desde la SC o activando "Monto manual"), fecha y hora de apertura,
+   estado público y observaciones.
+3. En la sub-página **Archivos públicos**, agregar la documentación (pliegos,
+   circulares, etc.), indicando el tipo y, si corresponde, marcando "Solicitar
+   email para descarga".
+4. Cuando la solicitud esté Finalizada/Adjudicada, cargar los **Adjudicatarios**
+   con su valor; el total adjudicado se calcula automáticamente.
+5. Presionar **Publicar en web**. Se registra la fecha de publicación y la
+   solicitud queda visible en ``/compras``. Usar **Despublicar** para retirarla.
+6. Usar el botón **Ver Sitio Web** para abrir la ficha pública en una pestaña
+   nueva.
+7. En el sitio público, los visitantes navegan el listado en
+   "Compras y Contrataciones", filtran por estado, abren el detalle y descargan
+   los archivos. Si un archivo exige email, se solicita antes de la descarga y
+   se registra en el log de descargas.
+
+Arquitectura
+============
+
+El módulo extiende ``purchase.requisition`` con un conjunto de campos de
+publicación y tres modelos satélite relacionados por Many2one con borrado en
+cascada: archivos públicos, adjudicatarios y log de descargas. La capa de
+presentación pública se resuelve con un controlador HTTP (``website=True``,
+``auth="public"``, accesos vía ``sudo()``) que renderiza plantillas QWeb,
+protegida por una ``ir.rule`` que limita la lectura pública a las solicitudes
+efectivamente publicadas. Las descargas con muro de email registran cada acceso
+en ``purchase.web.download.log``, alimentando el contador de descargas por
+archivo. El override de ``write`` mantiene la coherencia entre publicación y
+fecha de última actualización.
+
+Dependencias
+============
+
+- ``sipreco_purchase``
+- ``website``
+- ``mail``
+
+Autor
+=====
+
+ADHOC SA
+
+Licencia
+========
+
+AGPL-3

--- a/sipreco_purchase_web/__init__.py
+++ b/sipreco_purchase_web/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import controllers

--- a/sipreco_purchase_web/__manifest__.py
+++ b/sipreco_purchase_web/__manifest__.py
@@ -1,0 +1,26 @@
+{
+    'name': 'Sipreco Purchase Web Publication',
+    'version': '18.0.1.0.0',
+    'license': 'AGPL-3',
+    'author': 'ADHOC SA',
+    'website': 'www.adhoc.com.ar',
+    'category': 'Purchase',
+    'summary': 'Publicación web de Solicitudes de Compra',
+    'depends': [
+        'sipreco_purchase',
+        'website',
+        'mail',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'security/sipreco_purchase_web_security.xml',
+        'views/purchase_web_download_log_views.xml',
+        'views/purchase_requisition_web_views.xml',
+        'views/purchase_web_attachment_views.xml',
+        'views/purchase_web_award_views.xml',
+        'views/website_templates.xml',
+        'views/website_menu.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/sipreco_purchase_web/controllers/__init__.py
+++ b/sipreco_purchase_web/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/sipreco_purchase_web/controllers/main.py
+++ b/sipreco_purchase_web/controllers/main.py
@@ -1,0 +1,204 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+import logging
+import mimetypes
+from urllib.parse import urlencode
+
+from odoo.http import request
+
+from odoo import http
+
+_logger = logging.getLogger(__name__)
+
+_WEB_STATES = {
+    "open": "Para Apertura",
+    "evaluation": "En evaluación",
+    "awarded": "Adjudicada",
+    "finished": "Finalizada",
+    "void": "Desierta",
+    "failed": "Fracasada",
+    "suspended": "Suspendida",
+}
+
+# Tipos de archivo con etiqueta para plantilla
+_ATTACHMENT_TYPE_LABELS = {
+    "pliego": "Pliego",
+    "circular": "Circular aclaratoria/modificatoria",
+    "ddjj": "Declaración jurada",
+    "other": "Otro",
+}
+
+
+def _set_embed_headers(response):
+    # X-Frame-Options: ALLOWALL no existe en el estándar; basta con CSP
+    response.headers.pop("X-Frame-Options", None)
+    response.headers["Content-Security-Policy"] = "frame-ancestors *"
+
+
+class PurchaseWebController(http.Controller):
+    @http.route("/compras", type="http", auth="public", website=True)
+    def purchase_list(self, state=None, embed=False, **kwargs):
+        domain = [
+            ("website_published", "=", True),
+            ("web_publishable", "=", True),
+        ]
+        if state and state in _WEB_STATES:
+            domain.append(("web_state", "=", state))
+        Requisition = request.env["purchase.requisition"].sudo()
+        purchases = Requisition.search(
+            domain, order="web_publication_date desc, id desc"
+        )
+        template = (
+            "sipreco_purchase_web.purchase_list_embed_template"
+            if embed
+            else "sipreco_purchase_web.purchase_list_template"
+        )
+        response = request.render(
+            template,
+            {
+                "purchases": purchases,
+                "web_states": _WEB_STATES,
+                "current_state": state,
+                "page_name": "purchase_list",
+                "embed": bool(embed),
+            },
+        )
+        if embed:
+            _set_embed_headers(response)
+        return response
+
+    @http.route("/compras/<int:purchase_id>", type="http", auth="public", website=True)
+    def purchase_detail(self, purchase_id, embed=False, **kwargs):
+        Requisition = request.env["purchase.requisition"].sudo()
+        purchase = Requisition.search(
+            [
+                ("id", "=", purchase_id),
+                ("website_published", "=", True),
+                ("web_publishable", "=", True),
+            ],
+            limit=1,
+        )
+
+        if not purchase:
+            return request.not_found()
+
+        template = (
+            "sipreco_purchase_web.purchase_detail_embed_template"
+            if embed
+            else "sipreco_purchase_web.purchase_detail_template"
+        )
+        response = request.render(
+            template,
+            {
+                "purchase": purchase,
+                "web_states": _WEB_STATES,
+                "attachment_type_labels": _ATTACHMENT_TYPE_LABELS,
+                "page_name": "purchase_detail",
+                "embed": bool(embed),
+            },
+        )
+        if embed:
+            _set_embed_headers(response)
+        return response
+
+    @http.route(
+        "/compras/<int:purchase_id>/descargar/<int:attachment_line_id>",
+        type="http",
+        auth="public",
+        website=True,
+    )
+    def purchase_attachment_download(
+        self, purchase_id, attachment_line_id, embed=False, **kwargs
+    ):
+        attachment_line = (
+            request.env["purchase.web.attachment"]
+            .sudo()
+            .search(
+                [
+                    ("id", "=", attachment_line_id),
+                    ("requisition_id", "=", purchase_id),
+                    ("requisition_id.website_published", "=", True),
+                    ("requisition_id.web_publishable", "=", True),
+                ],
+                limit=1,
+            )
+        )
+        if not attachment_line:
+            return request.not_found()
+        purchase = attachment_line.requisition_id
+
+        if attachment_line.require_email:
+            email = kwargs.get("email", "").strip()
+            if not email:
+                template = (
+                    "sipreco_purchase_web.purchase_email_gate_embed_template"
+                    if embed
+                    else "sipreco_purchase_web.purchase_email_gate_template"
+                )
+                response = request.render(
+                    template,
+                    {
+                        "purchase": purchase,
+                        "attachment_line": attachment_line,
+                        "page_name": "purchase_email_gate",
+                        "embed": bool(embed),
+                    },
+                )
+                if embed:
+                    _set_embed_headers(response)
+                return response
+            _logger.info(
+                'Descarga de archivo "%s" (id=%s) por email: %s',
+                attachment_line.name,
+                attachment_line_id,
+                email,
+            )
+            request.env["purchase.web.download.log"].sudo().create(
+                {
+                    "attachment_line_id": attachment_line.id,
+                    "email": email,
+                }
+            )
+
+        if not attachment_line.attachment:
+            return request.not_found()
+
+        fname = attachment_line.attachment_fname or "archivo"
+        mimetype, _ = mimetypes.guess_type(fname)
+        stream = http.Stream.from_binary_field(attachment_line, 'attachment')
+        stream.download_name = fname
+        stream.as_attachment = True
+        if mimetype:
+            stream.mimetype = mimetype
+        return stream.get_response()
+
+    @http.route(
+        "/compras/<int:purchase_id>/descargar/<int:attachment_line_id>/email",
+        type="http",
+        auth="public",
+        website=True,
+        methods=["POST"],
+        csrf=True,
+    )
+    def purchase_attachment_email_submit(
+        self, purchase_id, attachment_line_id, email="", embed=False, **kwargs
+    ):
+        # Validación básica del email recibido por POST
+        email = email.strip()
+        base_url = "/compras/%d/descargar/%d" % (purchase_id, attachment_line_id)
+        if not email or "@" not in email:
+            params = {"embed": 1} if embed else {}
+            qs = "?" + urlencode(params) if params else ""
+            return request.redirect(base_url + qs)
+        _logger.info(
+            "Email registrado para descarga de archivo (requisition=%d, attachment=%d): %s",
+            purchase_id,
+            attachment_line_id,
+            email,
+        )
+        params = {"email": email}
+        if embed:
+            params["embed"] = 1
+        return request.redirect(base_url + "?" + urlencode(params))

--- a/sipreco_purchase_web/models/__init__.py
+++ b/sipreco_purchase_web/models/__init__.py
@@ -1,0 +1,4 @@
+from . import purchase_requisition
+from . import purchase_web_attachment
+from . import purchase_web_award
+from . import purchase_web_download_log

--- a/sipreco_purchase_web/models/purchase_requisition.py
+++ b/sipreco_purchase_web/models/purchase_requisition.py
@@ -1,0 +1,154 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models, fields, api, _
+
+
+class PurchaseRequisition(models.Model):
+    _inherit = 'purchase.requisition'
+
+    # -------------------------------------------------------------------------
+    # Publicación web
+    # -------------------------------------------------------------------------
+    web_publishable = fields.Boolean(
+        string='Publicable en web',
+        default=False,
+    )
+    website_published = fields.Boolean(
+        string='Publicado en web',
+        default=False,
+        copy=False,
+    )
+
+    # Datos públicos de identificación
+    web_number = fields.Char(
+        string='Número',
+        copy=False,
+    )
+    web_object = fields.Char(
+        string='Objeto',
+    )
+    web_amount = fields.Monetary(
+        string='Valor oficial',
+        currency_field='currency_id',
+    )
+    web_amount_manual = fields.Boolean(
+        string='Monto manual',
+        default=False,
+        help='Si está activo, el valor oficial no se toma de la SC sino que se carga manualmente.',
+    )
+
+    # Fechas públicas
+    web_opening_datetime = fields.Datetime(
+        string='Fecha y hora de Apertura',
+    )
+    web_publication_date = fields.Date(
+        string='Fecha de publicación',
+        copy=False,
+    )
+    web_last_update = fields.Datetime(
+        string='Fecha última actualización',
+        copy=False,
+    )
+
+    # Estado público
+    web_state = fields.Selection(
+        selection=[
+            ('open', 'Para Apertura'),
+            ('evaluation', 'En evaluación'),
+            ('awarded', 'Adjudicada'),
+            ('finished', 'Finalizada'),
+            ('void', 'Desierta'),
+            ('failed', 'Fracasada'),
+            ('suspended', 'Suspendida'),
+        ],
+        string='Estado público',
+        default='open',
+    )
+
+    # Observaciones
+    web_observations = fields.Html(
+        string='Observaciones',
+        sanitize=True,
+    )
+
+    # Relaciones con adjudicatarios (solo cuando web_state == 'finished')
+    web_award_ids = fields.One2many(
+        'purchase.web.award',
+        'requisition_id',
+        string='Adjudicatarios',
+    )
+    web_total_awarded = fields.Monetary(
+        string='Valor total adjudicado',
+        currency_field='currency_id',
+        compute='_compute_web_total_awarded',
+        store=True,
+    )
+
+    # Archivos públicos
+    web_attachment_ids = fields.One2many(
+        'purchase.web.attachment',
+        'requisition_id',
+        string='Archivos públicos',
+    )
+
+    # -------------------------------------------------------------------------
+    # Computes
+    # -------------------------------------------------------------------------
+    @api.depends('web_award_ids.amount')
+    def _compute_web_total_awarded(self):
+        grouped = self.env['purchase.web.award'].read_group(
+            [('requisition_id', 'in', self.ids)],
+            ['requisition_id', 'amount:sum'],
+            ['requisition_id'],
+        )
+        totals = {g['requisition_id'][0]: g['amount'] for g in grouped}
+        for rec in self:
+            rec.web_total_awarded = totals.get(rec.id, 0.0)
+
+    @api.onchange('web_amount_manual', 'amount_total')
+    def _onchange_web_amount_manual(self):
+        if not self.web_amount_manual:
+            self.web_amount = self.amount_total
+
+    # -------------------------------------------------------------------------
+    # Acciones
+    # -------------------------------------------------------------------------
+    def action_web_publish(self):
+        for rec in self:
+            if not rec.web_publishable:
+                continue
+            rec.website_published = True
+            if not rec.web_publication_date:
+                rec.web_publication_date = fields.Date.today()
+            rec.web_last_update = fields.Datetime.now()
+
+    def action_web_unpublish(self):
+        for rec in self:
+            rec.website_published = False
+
+    def action_view_website(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_url',
+            'url': '/compras/%d' % self.id,
+            'target': 'new',
+        }
+
+    @api.onchange('web_publishable')
+    def _onchange_web_publishable(self):
+        if not self.web_publishable and self.website_published:
+            self.website_published = False
+
+    def write(self, vals):
+        if 'web_publishable' in vals and not vals['web_publishable']:
+            vals['website_published'] = False
+        web_fields = {
+            'web_number', 'web_object', 'web_amount', 'web_amount_manual',
+            'web_opening_datetime', 'web_state', 'web_observations',
+            'web_attachment_ids', 'web_award_ids',
+        }
+        if vals.keys() & web_fields and self.filtered('website_published') and 'web_last_update' not in vals:
+            vals['web_last_update'] = fields.Datetime.now()
+        return super().write(vals)

--- a/sipreco_purchase_web/models/purchase_web_attachment.py
+++ b/sipreco_purchase_web/models/purchase_web_attachment.py
@@ -1,0 +1,75 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, models, fields
+
+
+class PurchaseWebAttachment(models.Model):
+    _name = 'purchase.web.attachment'
+    _description = 'Archivo público de Solicitud de Compra'
+    _order = 'sequence, id'
+
+    sequence = fields.Integer(default=10)
+    requisition_id = fields.Many2one(
+        'purchase.requisition',
+        string='Solicitud de Compra',
+        required=True,
+        ondelete='cascade',
+    )
+    name = fields.Char(
+        string='Descripción',
+        required=True,
+    )
+    attachment_type = fields.Selection(
+        selection=[
+            ('pliego', 'Pliego'),
+            ('circular', 'Circular aclaratoria/modificatoria'),
+            ('ddjj', 'Declaración jurada'),
+            ('other', 'Otro'),
+        ],
+        string='Tipo',
+        default='other',
+        required=True,
+    )
+    attachment = fields.Binary(
+        string='Archivo',
+    )
+    attachment_fname = fields.Char(
+        string='Nombre del archivo',
+    )
+    require_email = fields.Boolean(
+        string='Solicitar email para descarga',
+        default=False,
+    )
+    download_log_ids = fields.One2many(
+        'purchase.web.download.log',
+        'attachment_line_id',
+        string='Log de descargas',
+    )
+    download_count = fields.Integer(
+        string='Descargas',
+        compute='_compute_download_count',
+    )
+
+    @api.depends('download_log_ids')
+    def _compute_download_count(self):
+        grouped = self.env['purchase.web.download.log'].read_group(
+            [('attachment_line_id', 'in', self.ids)],
+            ['attachment_line_id'],
+            ['attachment_line_id'],
+        )
+        counts = {g['attachment_line_id'][0]: g['attachment_line_id_count'] for g in grouped}
+        for rec in self:
+            rec.download_count = counts.get(rec.id, 0)
+
+    def action_view_download_logs(self):
+        self.ensure_one()
+        return {
+            'name': 'Descargas — %s' % self.name,
+            'type': 'ir.actions.act_window',
+            'res_model': 'purchase.web.download.log',
+            'view_mode': 'list',
+            'domain': [('attachment_line_id', '=', self.id)],
+            'context': {'create': False},
+        }

--- a/sipreco_purchase_web/models/purchase_web_award.py
+++ b/sipreco_purchase_web/models/purchase_web_award.py
@@ -1,0 +1,34 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models, fields, api
+
+
+class PurchaseWebAward(models.Model):
+    _name = 'purchase.web.award'
+    _description = 'Adjudicatario de Solicitud de Compra'
+    _order = 'requisition_id, id'
+
+    requisition_id = fields.Many2one(
+        'purchase.requisition',
+        string='Solicitud de Compra',
+        required=True,
+        ondelete='cascade',
+    )
+    partner_id = fields.Many2one(
+        'res.partner',
+        string='Adjudicatario',
+        required=True,
+    )
+    amount = fields.Monetary(
+        string='Valor adjudicado',
+        currency_field='currency_id',
+    )
+    currency_id = fields.Many2one(
+        related='requisition_id.currency_id',
+        store=True,
+    )
+    notes = fields.Char(
+        string='Detalle',
+    )

--- a/sipreco_purchase_web/models/purchase_web_download_log.py
+++ b/sipreco_purchase_web/models/purchase_web_download_log.py
@@ -1,0 +1,32 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models, fields
+
+
+class PurchaseWebDownloadLog(models.Model):
+    _name = 'purchase.web.download.log'
+    _description = 'Log de descargas de archivos públicos'
+    _order = 'download_date desc'
+
+    attachment_line_id = fields.Many2one(
+        'purchase.web.attachment',
+        string='Archivo',
+        required=True,
+        ondelete='cascade',
+    )
+    requisition_id = fields.Many2one(
+        related='attachment_line_id.requisition_id',
+        store=True,
+        string='Solicitud de Compra',
+    )
+    email = fields.Char(
+        string='Email',
+        required=True,
+    )
+    download_date = fields.Datetime(
+        string='Fecha de descarga',
+        default=fields.Datetime.now,
+        readonly=True,
+    )

--- a/sipreco_purchase_web/security/ir.model.access.csv
+++ b/sipreco_purchase_web/security/ir.model.access.csv
@@ -1,0 +1,6 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_purchase_web_attachment_user,purchase.web.attachment.user,model_purchase_web_attachment,purchase.group_purchase_user,1,1,1,1
+access_purchase_web_attachment_public,purchase.web.attachment.public,model_purchase_web_attachment,base.group_public,1,0,0,0
+access_purchase_web_award_user,purchase.web.award.user,model_purchase_web_award,purchase.group_purchase_user,1,1,1,1
+access_purchase_web_award_public,purchase.web.award.public,model_purchase_web_award,base.group_public,1,0,0,0
+access_purchase_web_download_log_user,purchase.web.download.log.user,model_purchase_web_download_log,purchase.group_purchase_user,1,1,1,1

--- a/sipreco_purchase_web/security/sipreco_purchase_web_security.xml
+++ b/sipreco_purchase_web/security/sipreco_purchase_web_security.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+        <record model="ir.module.category" id="module_category_inventory_purchase_web_publish">
+            <field name="name">Publicación web de compras</field>
+            <field name="description">Gestion de publiacion web de compras en el sitio web</field>
+            <field name="sequence">10</field>
+        </record>
+
+        <record id="sipreco_web_publish" model="res.groups">
+            <field name="name">Publicar en la web</field>
+            <field name="implied_ids" eval="[(4, ref('purchase.group_purchase_user'))]" />
+            <field name="category_id" ref="module_category_inventory_purchase_web_publish" />
+        </record>
+
+
+        <!-- Regla de dominio: el público solo puede leer solicitudes publicadas -->
+        <record id="purchase_requisition_public_rule" model="ir.rule">
+            <field name="name">Solicitudes de Compra: solo publicadas para público</field>
+            <field name="model_id" ref="purchase_requisition.model_purchase_requisition" />
+            <field name="domain_force">[('website_published', '=', True), ('web_publishable', '=',
+                True)]</field>
+            <field name="groups" eval="[(4, ref('base.group_public'))]" />
+            <field name="perm_read" eval="True" />
+            <field name="perm_write" eval="False" />
+            <field name="perm_create" eval="False" />
+            <field name="perm_unlink" eval="False" />
+        </record>
+
+        <!-- Reglas de dominio: modelos hijo heredan la restricción de publicación del padre -->
+        <record id="purchase_web_attachment_public_rule" model="ir.rule">
+            <field name="name">Archivos de Compra: solo de solicitudes publicadas para público</field>
+            <field name="model_id" ref="model_purchase_web_attachment" />
+            <field name="domain_force">[('requisition_id.website_published', '=', True), ('requisition_id.web_publishable', '=', True)]</field>
+            <field name="groups" eval="[(4, ref('base.group_public'))]" />
+            <field name="perm_read" eval="True" />
+            <field name="perm_write" eval="False" />
+            <field name="perm_create" eval="False" />
+            <field name="perm_unlink" eval="False" />
+        </record>
+
+        <record id="purchase_web_award_public_rule" model="ir.rule">
+            <field name="name">Adjudicaciones de Compra: solo de solicitudes publicadas para público</field>
+            <field name="model_id" ref="model_purchase_web_award" />
+            <field name="domain_force">[('requisition_id.website_published', '=', True), ('requisition_id.web_publishable', '=', True)]</field>
+            <field name="groups" eval="[(4, ref('base.group_public'))]" />
+            <field name="perm_read" eval="True" />
+            <field name="perm_write" eval="False" />
+            <field name="perm_create" eval="False" />
+            <field name="perm_unlink" eval="False" />
+        </record>
+
+</odoo>

--- a/sipreco_purchase_web/views/purchase_requisition_web_views.xml
+++ b/sipreco_purchase_web/views/purchase_requisition_web_views.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_purchase_requisition_web_form">
+        <field name="name">purchase.requisition.web.form</field>
+        <field name="model">purchase.requisition</field>
+        <field name="priority">70</field>
+        <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_form" />
+        <field name="arch" type="xml">
+
+            <!-- Botón Publicar en web (visible solo si publicable y aún no publicado) -->
+            <button name="action_cancel" position="before">
+                <button name="action_web_publish"
+                    string="Publicar en web"
+                    type="object"
+                    class="btn-primary"
+                    invisible="not web_publishable or website_published"
+                    groups="sipreco_purchase_web.sipreco_web_publish" />
+                <button name="action_web_unpublish"
+                    string="Despublicar"
+                    type="object"
+                    class="btn-warning"
+                    invisible="not website_published"
+                    groups="sipreco_purchase_web.sipreco_web_publish" />
+            </button>
+
+            <!-- Indicador de publicación en button_box -->
+            <div name="button_box" position="inside">
+                <button class="oe_stat_button"
+                    type="object"
+                    name="action_view_website"
+                    icon="fa-globe"
+                    invisible="not website_published">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Ver Sitio Web</span>
+                    </div>
+                </button>
+            </div>
+
+            <!-- Campo "Publicable en web" en la cabecera del formulario -->
+            <field name="vendor_id" position="before">
+                <field name="web_publishable" groups="sipreco_purchase_web.sipreco_web_publish" />
+            </field>
+
+            <!-- Solapa "Datos para página web" visible solo si web_publishable -->
+            <xpath expr="//notebook" position="inside">
+                <page string="Datos para página web"
+                    name="web_publication"
+                    invisible="not web_publishable"
+                    groups="sipreco_purchase_web.sipreco_web_publish">
+                    <div class="text-end">
+                        <field name="web_state" widget="statusbar" options="{'clickable': '1'}" />
+                    </div>
+
+                    <group string="Identificación pública">
+                        <group>
+                            <field name="web_number" />
+                            <field name="web_object" />
+                            <field name="transaction_type_id" readonly="1" />
+                        </group>
+                        <group>
+                            <field name="web_amount_manual" />
+                            <field name="web_amount"
+                                readonly="not web_amount_manual" />
+                        </group>
+                    </group>
+
+                    <group string="Fechas y estado">
+                        <group>
+                            <field name="web_opening_datetime" />
+                            <field name="web_publication_date" readonly="1" />
+                            <field name="web_last_update" readonly="1" />
+                        </group>
+                    </group>
+
+                    <group string="Observaciones">
+                        <field name="web_observations" nolabel="1" />
+                    </group>
+
+                    <notebook>
+                        <page string="Archivos públicos" name="web_attachments">
+                            <field name="web_attachment_ids"
+                                context="{'default_requisition_id': id}">
+                                <list editable="bottom">
+                                    <field name="sequence" widget="handle" />
+                                    <field name="name" />
+                                    <field name="attachment_type" />
+                                    <field name="attachment" filename="attachment_fname" />
+                                    <field name="attachment_fname" column_invisible="1" />
+                                    <field name="require_email" />
+                                    <field name="download_count" readonly="1" />
+                                    <button name="action_view_download_logs"
+                                        type="object"
+                                        icon="fa-users"
+                                        title="Ver descargas"
+                                        groups="purchase.group_purchase_user" />
+                                </list>
+                            </field>
+                        </page>
+
+                        <page string="Adjudicatarios"
+                            name="web_awards"
+                            invisible="web_state not in ['finished','awarded']">
+                            <field name="web_award_ids" context="{'default_requisition_id': id}">
+                                <list editable="bottom">
+                                    <field name="partner_id" />
+                                    <field name="amount" />
+                                    <field name="notes" />
+                                </list>
+                            </field>
+                            <group>
+                                <field name="web_total_awarded" />
+                            </group>
+                        </page>
+                    </notebook>
+
+                </page>
+            </xpath>
+
+        </field>
+    </record>
+
+    <!-- Vista lista con indicador de publicación -->
+    <record model="ir.ui.view" id="view_purchase_requisition_web_list">
+        <field name="name">purchase.requisition.web.list</field>
+        <field name="model">purchase.requisition</field>
+        <field name="priority">70</field>
+        <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_tree" />
+        <field name="arch" type="xml">
+            <list>
+                <field name="web_publishable" optional="show" groups="sipreco_purchase_web.sipreco_web_publish"/>
+                <field name="website_published" optional="show"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Filtros de búsqueda adicionales -->
+    <record model="ir.ui.view" id="view_purchase_requisition_web_search">
+        <field name="name">purchase.requisition.web.search</field>
+        <field name="model">purchase.requisition</field>
+        <field name="priority">70</field>
+        <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_filter" />
+        <field name="arch" type="xml">
+            <search>
+                <filter string="Publicables en web" name="web_publishable"
+                    domain="[('web_publishable', '=', True)]" />
+                <filter string="Publicadas en web" name="website_published"
+                    domain="[('website_published', '=', True)]" />
+            </search>
+        </field>
+    </record>
+
+</odoo>

--- a/sipreco_purchase_web/views/purchase_web_attachment_views.xml
+++ b/sipreco_purchase_web/views/purchase_web_attachment_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_purchase_web_attachment_form">
+        <field name="name">purchase.web.attachment.form</field>
+        <field name="model">purchase.web.attachment</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div name="button_box" class="oe_button_box">
+                        <button class="oe_stat_button"
+                                type="action"
+                                name="%(sipreco_purchase_web.action_purchase_web_download_log)d"
+                                icon="fa-download"
+                                groups="purchase.group_purchase_user">
+                            <field name="download_count" widget="statinfo" string="Descargas"/>
+                        </button>
+                    </div>
+                    <group>
+                        <field name="requisition_id"/>
+                        <field name="name"/>
+                        <field name="attachment_type"/>
+                        <field name="attachment" filename="attachment_fname"/>
+                        <field name="attachment_fname" invisible="1"/>
+                        <field name="require_email"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/sipreco_purchase_web/views/purchase_web_award_views.xml
+++ b/sipreco_purchase_web/views/purchase_web_award_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_purchase_web_award_form">
+        <field name="name">purchase.web.award.form</field>
+        <field name="model">purchase.web.award</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="requisition_id"/>
+                        <field name="partner_id"/>
+                        <field name="amount"/>
+                        <field name="notes"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/sipreco_purchase_web/views/purchase_web_download_log_views.xml
+++ b/sipreco_purchase_web/views/purchase_web_download_log_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_purchase_web_download_log_list">
+        <field name="name">purchase.web.download.log.list</field>
+        <field name="model">purchase.web.download.log</field>
+        <field name="arch" type="xml">
+            <list create="false" edit="false" delete="false">
+                <field name="download_date"/>
+                <field name="email"/>
+                <field name="attachment_line_id"/>
+                <field name="requisition_id"/>
+            </list>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="action_purchase_web_download_log">
+        <field name="name">Descargas</field>
+        <field name="res_model">purchase.web.download.log</field>
+        <field name="view_mode">list</field>
+        <field name="domain">[('attachment_line_id', '=', active_id)]</field>
+    </record>
+
+</odoo>

--- a/sipreco_purchase_web/views/website_menu.xml
+++ b/sipreco_purchase_web/views/website_menu.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="website_menu_compras" model="website.menu">
+        <field name="name">Compras y Contrataciones</field>
+        <field name="url">/compras</field>
+        <field name="sequence">50</field>
+        <field name="website_id" ref="website.default_website"/>
+        <field name="parent_id" ref="website.main_menu"/>
+    </record>
+
+</odoo>

--- a/sipreco_purchase_web/views/website_templates.xml
+++ b/sipreco_purchase_web/views/website_templates.xml
@@ -1,0 +1,577 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- ================================================================
+         LAYOUT BASE (heredado del website de Odoo)
+    ================================================================ -->
+
+    <!-- Listado de compras publicadas -->
+    <template id="purchase_list_template" name="Compras - Listado público">
+        <t t-call="website.layout">
+            <t t-set="title">Compras y Contrataciones</t>
+            <div class="o_wcompras">
+                <div class="container mt-4 mb-5">
+                    <h1 class="mb-4">Compras y Contrataciones</h1>
+
+                    <!-- Filtros por estado -->
+                    <div class="mb-4 d-flex flex-wrap gap-2">
+                        <a href="/compras"
+                           t-attf-class="btn btn-sm #{not current_state and 'btn-dark' or 'btn-outline-secondary'}">
+                            Todos
+                        </a>
+                        <t t-foreach="web_states.items()" t-as="state_item">
+                            <a t-attf-href="/compras?state=#{state_item[0]}"
+                               t-attf-class="btn btn-sm #{current_state == state_item[0] and 'btn-dark' or 'btn-outline-secondary'}">
+                                <t t-esc="state_item[1]"/>
+                            </a>
+                        </t>
+                    </div>
+
+                    <t t-if="not purchases">
+                        <div class="alert alert-info">
+                            No hay compras publicadas actualmente.
+                        </div>
+                    </t>
+
+                    <t t-foreach="purchases" t-as="purchase">
+                        <div class="card mb-3 shadow-sm">
+                            <div class="card-body">
+                                <div class="row align-items-center">
+                                    <div class="col-md-8">
+                                        <h5 class="card-title mb-1">
+                                            <t t-if="purchase.web_number">
+                                                <span class="text-muted me-2">
+                                                    <t t-esc="purchase.web_number"/>
+                                                </span>
+                                            </t>
+                                            <t t-esc="purchase.web_object or purchase.name"/>
+                                        </h5>
+                                        <small class="text-muted">
+                                            Tipo:
+                                            <t t-esc="purchase.transaction_type_id.name or '-'"/>
+                                        </small>
+                                        <t t-if="purchase.web_opening_datetime">
+                                            <small class="d-block text-muted">
+                                                Apertura:
+                                                <span t-field="purchase.web_opening_datetime"/>
+                                            </small>
+                                        </t>
+                                    </div>
+                                    <div class="col-md-2 text-center">
+                                        <t t-set="state_label" t-value="web_states.get(purchase.web_state, purchase.web_state)"/>
+                                        <t t-set="state_css" t-value="'bg-primary' if purchase.web_state == 'open' else 'bg-warning text-dark' if purchase.web_state == 'evaluation' else 'bg-success' if purchase.web_state == 'awarded' else 'bg-secondary' if purchase.web_state == 'finished' else 'bg-danger'"/>
+                                        <span t-att-class="'badge ' + state_css">
+                                            <t t-esc="state_label"/>
+                                        </span>
+                                    </div>
+                                    <div class="col-md-2 text-end">
+                                        <a t-attf-href="/compras/#{purchase.id}"
+                                           class="btn btn-sm btn-outline-primary">
+                                            Ver detalle
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </t>
+    </template>
+
+    <!-- Detalle de una compra publicada -->
+    <template id="purchase_detail_template" name="Compras - Detalle">
+        <t t-call="website.layout">
+            <t t-set="title" t-value="purchase.web_object or purchase.name"/>
+            <div class="o_wcompras_detail">
+                <div class="container mt-4 mb-5">
+
+                    <!-- Breadcrumb -->
+                    <nav aria-label="breadcrumb">
+                        <ol class="breadcrumb">
+                            <li class="breadcrumb-item">
+                                <a href="/compras">Compras y Contrataciones</a>
+                            </li>
+                            <li class="breadcrumb-item active" aria-current="page">
+                                <t t-esc="purchase.web_number or purchase.name"/>
+                            </li>
+                        </ol>
+                    </nav>
+
+                    <div class="row">
+                        <div class="col-lg-8">
+                            <h1 class="mb-1">
+                                <t t-esc="purchase.web_object or purchase.name"/>
+                            </h1>
+
+                            <!-- Estado público -->
+                            <t t-set="state_label" t-value="web_states.get(purchase.web_state, purchase.web_state)"/>
+                            <t t-set="state_css" t-value="'bg-primary' if purchase.web_state == 'open' else 'bg-warning text-dark' if purchase.web_state == 'evaluation' else 'bg-success' if purchase.web_state == 'awarded' else 'bg-secondary' if purchase.web_state == 'finished' else 'bg-danger'"/>
+                            <span t-att-class="'badge fs-6 mb-3 ' + state_css">
+                                <t t-esc="state_label"/>
+                            </span>
+
+                            <hr/>
+
+                            <!-- Datos básicos -->
+                            <dl class="row">
+                                <t t-if="purchase.web_number">
+                                    <dt class="col-sm-4">Número</dt>
+                                    <dd class="col-sm-8"><t t-esc="purchase.web_number"/></dd>
+                                </t>
+                                <t t-if="purchase.transaction_type_id">
+                                    <dt class="col-sm-4">Tipo de compra</dt>
+                                    <dd class="col-sm-8">
+                                        <t t-esc="purchase.transaction_type_id.name"/>
+                                    </dd>
+                                </t>
+                                <dt class="col-sm-4">Valor oficial</dt>
+                                <dd class="col-sm-8">
+                                    <t t-esc="purchase.currency_id.symbol"/>&#160;
+                                    <t t-esc="'{:,.2f}'.format(purchase.web_amount if purchase.web_amount_manual else purchase.amount_total)"/>
+                                </dd>
+                                <t t-if="purchase.web_opening_datetime">
+                                    <dt class="col-sm-4">Fecha y hora de Apertura</dt>
+                                    <dd class="col-sm-8">
+                                        <span t-field="purchase.web_opening_datetime"/>
+                                    </dd>
+                                </t>
+                                <t t-if="purchase.web_publication_date">
+                                    <dt class="col-sm-4">Fecha de publicación</dt>
+                                    <dd class="col-sm-8">
+                                        <span t-field="purchase.web_publication_date"/>
+                                    </dd>
+                                </t>
+                                <t t-if="purchase.web_last_update">
+                                    <dt class="col-sm-4">Última actualización</dt>
+                                    <dd class="col-sm-8">
+                                        <span t-field="purchase.web_last_update"/>
+                                    </dd>
+                                </t>
+                            </dl>
+
+                            <!-- Observaciones -->
+                            <t t-if="purchase.web_observations">
+                                <h4 class="mt-4">Observaciones</h4>
+                                <div t-field="purchase.web_observations"/>
+                            </t>
+
+                            <!-- Adjudicatarios (solo estado Finalizada) -->
+                            <t t-if="purchase.web_state in ['finished','awarded'] and purchase.web_award_ids">
+                                <h4 class="mt-4">Adjudicación</h4>
+                                <table class="table table-bordered">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th>Adjudicatario</th>
+                                            <th>Valor adjudicado</th>
+                                            <th>Detalle</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <t t-foreach="purchase.web_award_ids" t-as="award">
+                                            <tr>
+                                                <td><t t-esc="award.partner_id.name"/></td>
+                                                <td>
+                                                    <t t-esc="award.currency_id.symbol"/>&#160;
+                                                    <t t-esc="'{:,.2f}'.format(award.amount)"/>
+                                                </td>
+                                                <td><t t-esc="award.notes or ''"/></td>
+                                            </tr>
+                                        </t>
+                                    </tbody>
+                                    <tfoot>
+                                        <tr class="fw-bold">
+                                            <td>Total adjudicado</td>
+                                            <td>
+                                                <t t-esc="purchase.currency_id.symbol"/>&#160;
+                                                <t t-esc="'{:,.2f}'.format(purchase.web_total_awarded)"/>
+                                            </td>
+                                            <td></td>
+                                        </tr>
+                                    </tfoot>
+                                </table>
+                            </t>
+
+                        </div>
+
+                        <!-- Columna lateral: archivos descargables -->
+                        <div class="col-lg-4">
+                            <div class="card">
+                                <div class="card-header fw-bold">
+                                    Documentación
+                                </div>
+                                <ul class="list-group list-group-flush">
+                                    <t t-if="not purchase.web_attachment_ids">
+                                        <li class="list-group-item text-muted">
+                                            Sin archivos disponibles.
+                                        </li>
+                                    </t>
+                                    <t t-foreach="purchase.web_attachment_ids" t-as="att">
+                                        <li class="list-group-item">
+                                            <a t-attf-href="/compras/#{purchase.id}/descargar/#{att.id}"
+                                               class="d-flex align-items-center gap-2">
+                                                <i class="fa fa-download text-primary"/>
+                                                <span>
+                                                    <t t-esc="att.name"/>
+                                                    <small class="d-block text-muted">
+                                                        <t t-esc="attachment_type_labels.get(att.attachment_type, '')"/>
+                                                    </small>
+                                                </span>
+                                            </a>
+                                        </li>
+                                    </t>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </t>
+    </template>
+
+    <!-- Listado embed (sin layout de website, para uso en iframe externo) -->
+    <template id="purchase_list_embed_template" name="Compras - Listado público (embed)">
+        <html>
+            <head>
+                <meta charset="utf-8"/>
+                <meta name="viewport" content="width=device-width, initial-scale=1"/>
+                <title>Compras y Contrataciones</title>
+                <link rel="stylesheet" href="/web/static/lib/bootstrap/dist/css/bootstrap.css"/>
+                <link rel="stylesheet" href="/web/static/src/libs/fontawesome/css/font-awesome.css"/>
+            </head>
+            <body>
+                <div class="o_wcompras">
+                    <div class="container mt-4 mb-5">
+                        <h1 class="mb-4">Compras y Contrataciones</h1>
+
+                        <!-- Filtros por estado -->
+                        <div class="mb-4 d-flex flex-wrap gap-2">
+                            <a href="/compras?embed=1"
+                               t-attf-class="btn btn-sm #{not current_state and 'btn-dark' or 'btn-outline-secondary'}">
+                                Todos
+                            </a>
+                            <t t-foreach="web_states.items()" t-as="state_item">
+                                <a t-attf-href="/compras?state=#{state_item[0]}&amp;embed=1"
+                                   t-attf-class="btn btn-sm #{current_state == state_item[0] and 'btn-dark' or 'btn-outline-secondary'}">
+                                    <t t-esc="state_item[1]"/>
+                                </a>
+                            </t>
+                        </div>
+
+                        <t t-if="not purchases">
+                            <div class="alert alert-info">
+                                No hay compras publicadas actualmente.
+                            </div>
+                        </t>
+
+                        <t t-foreach="purchases" t-as="purchase">
+                            <div class="card mb-3 shadow-sm">
+                                <div class="card-body">
+                                    <div class="row align-items-center">
+                                        <div class="col-md-8">
+                                            <h5 class="card-title mb-1">
+                                                <t t-if="purchase.web_number">
+                                                    <span class="text-muted me-2">
+                                                        <t t-esc="purchase.web_number"/>
+                                                    </span>
+                                                </t>
+                                                <t t-esc="purchase.web_object or purchase.name"/>
+                                            </h5>
+                                            <small class="text-muted">
+                                                Tipo:
+                                                <t t-esc="purchase.transaction_type_id.name or '-'"/>
+                                            </small>
+                                            <t t-if="purchase.web_opening_datetime">
+                                                <small class="d-block text-muted">
+                                                    Apertura:
+                                                    <span t-field="purchase.web_opening_datetime"/>
+                                                </small>
+                                            </t>
+                                        </div>
+                                        <div class="col-md-2 text-center">
+                                            <t t-set="state_label" t-value="web_states.get(purchase.web_state, purchase.web_state)"/>
+                                            <t t-set="state_css" t-value="'bg-primary' if purchase.web_state == 'open' else 'bg-warning text-dark' if purchase.web_state == 'evaluation' else 'bg-success' if purchase.web_state == 'awarded' else 'bg-secondary' if purchase.web_state == 'finished' else 'bg-danger'"/>
+                                            <span t-att-class="'badge ' + state_css">
+                                                <t t-esc="state_label"/>
+                                            </span>
+                                        </div>
+                                        <div class="col-md-2 text-end">
+                                            <a t-attf-href="/compras/#{purchase.id}?embed=1"
+                                               class="btn btn-sm btn-outline-primary">
+                                                Ver detalle
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </t>
+                    </div>
+                </div>
+            </body>
+        </html>
+    </template>
+
+    <!-- Detalle embed (sin layout de website, para uso en iframe externo) -->
+    <template id="purchase_detail_embed_template" name="Compras - Detalle (embed)">
+        <html>
+            <head>
+                <meta charset="utf-8"/>
+                <meta name="viewport" content="width=device-width, initial-scale=1"/>
+                <t t-set="page_title" t-value="purchase.web_object or purchase.name"/>
+                <title><t t-esc="page_title"/></title>
+                <link rel="stylesheet" href="/web/static/lib/bootstrap/dist/css/bootstrap.css"/>
+                <link rel="stylesheet" href="/web/static/src/libs/fontawesome/css/font-awesome.css"/>
+            </head>
+            <body>
+                <div class="o_wcompras_detail">
+                    <div class="container mt-4 mb-5">
+
+                        <!-- Breadcrumb -->
+                        <nav aria-label="breadcrumb">
+                            <ol class="breadcrumb">
+                                <li class="breadcrumb-item">
+                                    <a href="/compras?embed=1">Compras y Contrataciones</a>
+                                </li>
+                                <li class="breadcrumb-item active" aria-current="page">
+                                    <t t-esc="purchase.web_number or purchase.name"/>
+                                </li>
+                            </ol>
+                        </nav>
+
+                        <div class="row">
+                            <div class="col-lg-8">
+                                <h1 class="mb-1">
+                                    <t t-esc="purchase.web_object or purchase.name"/>
+                                </h1>
+
+                                <!-- Estado público -->
+                                <t t-set="state_label" t-value="web_states.get(purchase.web_state, purchase.web_state)"/>
+                                <t t-set="state_css" t-value="'bg-primary' if purchase.web_state == 'open' else 'bg-warning text-dark' if purchase.web_state == 'evaluation' else 'bg-success' if purchase.web_state == 'awarded' else 'bg-secondary' if purchase.web_state == 'finished' else 'bg-danger'"/>
+                                <span t-att-class="'badge fs-6 mb-3 ' + state_css">
+                                    <t t-esc="state_label"/>
+                                </span>
+
+                                <hr/>
+
+                                <!-- Datos básicos -->
+                                <dl class="row">
+                                    <t t-if="purchase.web_number">
+                                        <dt class="col-sm-4">Número</dt>
+                                        <dd class="col-sm-8"><t t-esc="purchase.web_number"/></dd>
+                                    </t>
+                                    <t t-if="purchase.transaction_type_id">
+                                        <dt class="col-sm-4">Tipo de compra</dt>
+                                        <dd class="col-sm-8">
+                                            <t t-esc="purchase.transaction_type_id.name"/>
+                                        </dd>
+                                    </t>
+                                    <dt class="col-sm-4">Valor oficial</dt>
+                                    <dd class="col-sm-8">
+                                        <t t-esc="purchase.currency_id.symbol"/>&#160;
+                                        <t t-esc="'{:,.2f}'.format(purchase.web_amount if purchase.web_amount_manual else purchase.amount_total)"/>
+                                    </dd>
+                                    <t t-if="purchase.web_opening_datetime">
+                                        <dt class="col-sm-4">Fecha y hora de Apertura</dt>
+                                        <dd class="col-sm-8">
+                                            <span t-field="purchase.web_opening_datetime"/>
+                                        </dd>
+                                    </t>
+                                    <t t-if="purchase.web_publication_date">
+                                        <dt class="col-sm-4">Fecha de publicación</dt>
+                                        <dd class="col-sm-8">
+                                            <span t-field="purchase.web_publication_date"/>
+                                        </dd>
+                                    </t>
+                                    <t t-if="purchase.web_last_update">
+                                        <dt class="col-sm-4">Última actualización</dt>
+                                        <dd class="col-sm-8">
+                                            <span t-field="purchase.web_last_update"/>
+                                        </dd>
+                                    </t>
+                                </dl>
+
+                                <!-- Observaciones -->
+                                <t t-if="purchase.web_observations">
+                                    <h4 class="mt-4">Observaciones</h4>
+                                    <div t-field="purchase.web_observations"/>
+                                </t>
+
+                                <!-- Adjudicatarios (solo estado Finalizada/Adjudicada) -->
+                                <t t-if="purchase.web_state in ['finished','awarded'] and purchase.web_award_ids">
+                                    <h4 class="mt-4">Adjudicación</h4>
+                                    <table class="table table-bordered">
+                                        <thead class="table-light">
+                                            <tr>
+                                                <th>Adjudicatario</th>
+                                                <th>Valor adjudicado</th>
+                                                <th>Detalle</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <t t-foreach="purchase.web_award_ids" t-as="award">
+                                                <tr>
+                                                    <td><t t-esc="award.partner_id.name"/></td>
+                                                    <td>
+                                                        <t t-esc="award.currency_id.symbol"/>&#160;
+                                                        <t t-esc="'{:,.2f}'.format(award.amount)"/>
+                                                    </td>
+                                                    <td><t t-esc="award.notes or ''"/></td>
+                                                </tr>
+                                            </t>
+                                        </tbody>
+                                        <tfoot>
+                                            <tr class="fw-bold">
+                                                <td>Total adjudicado</td>
+                                                <td>
+                                                    <t t-esc="purchase.currency_id.symbol"/>&#160;
+                                                    <t t-esc="'{:,.2f}'.format(purchase.web_total_awarded)"/>
+                                                </td>
+                                                <td></td>
+                                            </tr>
+                                        </tfoot>
+                                    </table>
+                                </t>
+
+                            </div>
+
+                            <!-- Columna lateral: archivos descargables -->
+                            <div class="col-lg-4">
+                                <div class="card">
+                                    <div class="card-header fw-bold">
+                                        Documentación
+                                    </div>
+                                    <ul class="list-group list-group-flush">
+                                        <t t-if="not purchase.web_attachment_ids">
+                                            <li class="list-group-item text-muted">
+                                                Sin archivos disponibles.
+                                            </li>
+                                        </t>
+                                        <t t-foreach="purchase.web_attachment_ids" t-as="att">
+                                            <li class="list-group-item">
+                                                <a t-attf-href="/compras/#{purchase.id}/descargar/#{att.id}?embed=1"
+                                                   class="d-flex align-items-center gap-2">
+                                                    <i class="fa fa-download text-primary"/>
+                                                    <span>
+                                                        <t t-esc="att.name"/>
+                                                        <small class="d-block text-muted">
+                                                            <t t-esc="attachment_type_labels.get(att.attachment_type, '')"/>
+                                                        </small>
+                                                    </span>
+                                                </a>
+                                            </li>
+                                        </t>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </body>
+        </html>
+    </template>
+
+    <!-- Gate de email embed (sin layout de website, para uso en iframe externo) -->
+    <template id="purchase_email_gate_embed_template" name="Compras - Solicitud de email (embed)">
+        <html>
+            <head>
+                <meta charset="utf-8"/>
+                <meta name="viewport" content="width=device-width, initial-scale=1"/>
+                <title>Descarga de documento</title>
+                <link rel="stylesheet" href="/web/static/lib/bootstrap/dist/css/bootstrap.css"/>
+            </head>
+            <body>
+                <div class="container mt-5 mb-5">
+                    <div class="row justify-content-center">
+                        <div class="col-md-8">
+                            <div class="card shadow-sm">
+                                <div class="card-body">
+                                    <h4 class="card-title mb-3">Descarga de documento</h4>
+                                    <p>
+                                        Para descargar
+                                        <strong><t t-esc="attachment_line.name"/></strong>
+                                        de la licitación
+                                        <strong>
+                                            <t t-esc="purchase.web_object or purchase.name"/>
+                                        </strong>,
+                                        por favor ingrese su correo electrónico.
+                                    </p>
+                                    <form t-attf-action="/compras/#{purchase.id}/descargar/#{attachment_line.id}/email"
+                                          method="post">
+                                        <input type="hidden" name="csrf_token"
+                                               t-att-value="request.csrf_token()"/>
+                                        <input type="hidden" name="embed" value="1"/>
+                                        <div class="mb-3">
+                                            <label for="email" class="form-label">
+                                                Correo electrónico
+                                            </label>
+                                            <input type="email" class="form-control"
+                                                   id="email" name="email" required="required"/>
+                                        </div>
+                                        <button type="submit" class="btn btn-primary w-100">
+                                            Descargar
+                                        </button>
+                                    </form>
+                                    <div class="mt-2 text-center">
+                                        <a t-attf-href="/compras/#{purchase.id}?embed=1">
+                                            ← Volver al detalle
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </body>
+        </html>
+    </template>
+
+    <!-- Formulario de email previo a la descarga del legajo -->
+    <template id="purchase_email_gate_template" name="Compras - Solicitud de email">
+        <t t-call="website.layout">
+            <t t-set="title">Descarga de documento</t>
+            <div class="container mt-5 mb-5">
+                <div class="row justify-content-center">
+                    <div class="col-md-6">
+                        <div class="card shadow-sm">
+                            <div class="card-body">
+                                <h4 class="card-title mb-3">Descarga de documento</h4>
+                                <p>
+                                    Para descargar
+                                    <strong><t t-esc="attachment_line.name"/></strong>
+                                    de la licitación
+                                    <strong>
+                                        <t t-esc="purchase.web_object or purchase.name"/>
+                                    </strong>,
+                                    por favor ingrese su correo electrónico.
+                                </p>
+                                <form t-attf-action="/compras/#{purchase.id}/descargar/#{attachment_line.id}/email"
+                                      method="post">
+                                    <input type="hidden" name="csrf_token"
+                                           t-att-value="request.csrf_token()"/>
+                                    <div class="mb-3">
+                                        <label for="email" class="form-label">
+                                            Correo electrónico
+                                        </label>
+                                        <input type="email" class="form-control"
+                                               id="email" name="email" required="required"/>
+                                    </div>
+                                    <button type="submit" class="btn btn-primary w-100">
+                                        Descargar
+                                    </button>
+                                </form>
+                                <div class="mt-2 text-center">
+                                    <a t-attf-href="/compras/#{purchase.id}">
+                                        ← Volver al detalle
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+
+</odoo>


### PR DESCRIPTION
task: 67731

Nuevo módulo que permite publicar Solicitudes de Compra (purchase.requisition) en una página web pública de compras y contrataciones, accesible en /compras.

Funcionalidades incluidas:

- Campo booleano "Publicable en web" en la Solicitud de Compra.
- Solapa "Datos para página web" visible solo cuando el booleano está activo, con: número, objeto, tipo de compra, valor oficial (manual o desde la SC), fecha/hora de apertura, estado público (Para Apertura, En evaluación, Adjudicada, Finalizada, Desierta, Fracasada, Suspendida), observaciones (rich text), archivos públicos descargables (pliego, circulares, DDJJ) y sección de adjudicatarios con valor total adjudicado (solo estado Finalizada).
- Fechas de publicación y última actualización generadas automáticamente.
- Botones "Publicar en web" y "Despublicar" en la botonera del formulario.
- Página pública /compras con listado y detalle de cada llamado.
- Descarga de archivos con opción de solicitar email previo a la descarga.
- Reglas de seguridad: el público solo accede a registros publicados; escritura restringida a purchase.group_purchase_user.

Depende de: sipreco_purchase, website, mail.