### PR TITLE
[IMP] sipreco_purchase: When creating a purchase order from a stock r…

### DIFF
--- a/sipreco_purchase/models/purchase_order.py
+++ b/sipreco_purchase/models/purchase_order.py
@@ -14,12 +14,11 @@ class PurchaseOrder(models.Model):
         copy=False,
     )
 
-    # @api.onchange('requisition_id')
-    # def _onchange_requisition_id(self):
-    #     super(PurchaseOrder, self)._onchange_requisition_id()
-    #     if self.requisition_id.type_id.line_copy == 'copy'\
-    #             and self.requisition_id.type_id.price_unit_copy != 'copy':
-    #         self.order_line.update({'price_unit': 0.0})
+    @api.onchange('requisition_id')
+    def _onchange_requisition_id(self):
+        super()._onchange_requisition_id()
+        if self.requisition_id and self.order_line:
+            self.order_line.update({'price_unit': 0.0})
 
     def check_if_expedients_exist(self):
         purchase_orders_expedient = self.filtered('expedient_id')

--- a/sipreco_purchase/models/purchase_order_line.py
+++ b/sipreco_purchase/models/purchase_order_line.py
@@ -10,3 +10,10 @@ class PurchaseOrderLine(models.Model):
 
     brand = fields.Char(
     )
+
+    def _compute_price_unit_and_date_planned_and_name(self):
+        lines_with_requisition = self.filtered(lambda l: l.order_id.requisition_id)
+        saved_prices = {pol.id: pol.price_unit for pol in lines_with_requisition}
+        super()._compute_price_unit_and_date_planned_and_name()
+        for pol in lines_with_requisition:
+            pol.price_unit = saved_prices.get(pol.id, 0.0)

--- a/sipreco_purchase/models/purchase_requisition.py
+++ b/sipreco_purchase/models/purchase_requisition.py
@@ -9,6 +9,10 @@ from odoo.exceptions import UserError
 class PurchaseRequisition(models.Model):
     _inherit = 'purchase.requisition'
 
+    state = fields.Selection(
+        tracking=True,
+    )
+
    # Cambiamos el default para que no requira tener vendor por defecto
     requisition_type = fields.Selection(default='purchase_template')
     manual_request_ids = fields.One2many(

--- a/sipreco_purchase/models/purchase_requisition_line.py
+++ b/sipreco_purchase/models/purchase_requisition_line.py
@@ -28,7 +28,7 @@ class PurchaseRequisitionLine(models.Model):
     def _prepare_purchase_order_line(
             self, name, product_qty=0.0, price_unit=0.0, taxes_ids=False):
         res = super()._prepare_purchase_order_line(
-            name, product_qty=product_qty, price_unit=price_unit,
+            name, product_qty=product_qty, price_unit=0.0,
             taxes_ids=taxes_ids)
         if self.name:
             res.update({

--- a/sipreco_purchase/models/stock_request_order.py
+++ b/sipreco_purchase/models/stock_request_order.py
@@ -8,6 +8,10 @@ from odoo import models, fields, api
 class StockRequestOrder(models.Model):
     _inherit = 'stock.request.order'
 
+    state = fields.Selection(
+        tracking=True,
+    )
+
     partner_id = fields.Many2one(
         'res.partner',
         'Requirente',

--- a/sipreco_purchase/views/purchase_requisition_views.xml
+++ b/sipreco_purchase/views/purchase_requisition_views.xml
@@ -39,23 +39,9 @@
                 <attribute name="string">Confirm</attribute>
                 <attribute name="invisible">state != 'draft' or not inspected</attribute>
             </button>
-
-            <!-- como al cancelar se cancelan los request, no dejamos re-abrir ya que es engañoso, lo dejamos son para nosotros -->
-            <!-- <button name="tender_reset" position="attributes">
-                <attribute name="groups">base.group_no_one</attribute>
-            </button> -->
-
-            <!-- al final no lo agregamos porque hay workflow vinculado y la complica -->
-            <!-- agregamos este boton para nosotros para poder re abrir si se confunden, solo para nosotros ya que podrian haber confirmado algun presupuesto. -->
-            <!-- <button name="open_bid" position="after">
-                <button name="back_to_confirm" states="open" string="Back To Confirm" type="object" groups="base.group_no_one"/>
-            </button> -->
-
-            <!-- es cerrar proceso de licitación y pasar a elegir -->
-            <!-- <button name="action_open" position="attributes">
-                <attribute name="confirm">ATENCIÓN: Se va a proceder a la selección de las ordenes de compra. No se podrán generar nuevas ordenes de compra. Esto no puede deshacerse. Seguro desea continuar?</attribute>
-            </button> -->
-
+            <xpath expr="//field[@name='state']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
 
             <div name="button_box">
                 <button class="oe_stat_button" name="%(stock_request.action_stock_request_form)d" string="Solicitudes" type="action" context="{'search_default_manual_requisition_id': id}" icon="fa-bars" groups="stock.group_stock_user"/>


### PR DESCRIPTION
…equest order, the purchase order should be linked to the stock request order, and the origin of the purchase order should be the name of the stock request order. This allows for better traceability and organization of related documents in the procurement process.