### PR TITLE
[FIX] public_budget: ajustar amount neto en alta masiva de OP con retenciones

### DIFF
--- a/public_budget/models/transaction.py
+++ b/public_budget/models/transaction.py
@@ -422,7 +422,7 @@ class BudgetTransaction(models.Model):
                 -sum(to_pay_move_lines.mapped('amount_residual')))
             if invoice.currency_id.compare_amounts(amount, 0.0) <= 0:
                 continue
-            self.env['account.payment'].with_context(pay_now=True).create({
+            payment = self.env['account.payment'].with_context(pay_now=True).create({
                     'partner_type': 'supplier',
                     'payment_type': 'outbound',
                     'receiptbook_id': self.budget_id.receiptbook_id.id,
@@ -433,6 +433,16 @@ class BudgetTransaction(models.Model):
                     'to_pay_move_line_ids': [(6, False, to_pay_move_lines.ids)],
                     'amount': amount,
                 })
+            # l10n_ar_tax suma las retenciones a payment_total (signo +1 para proveedor
+            # outbound), dejando payment_difference = -withholdings_amount. En el flujo
+            # manual _onchange_withholdings descuenta ese valor del amount, pero en la
+            # creación programática el onchange no dispara. Aplicamos el mismo ajuste
+            # para que amount quede en neto y payment_total == to_pay_amount.
+            if payment.payment_difference:
+                new_amount = payment.amount + payment.payment_difference
+                payment.with_context(
+                    skip_account_move_synchronization=True
+                ).amount = new_amount if new_amount > 0 else 0
         return True
 
     @api.depends(


### PR DESCRIPTION
## Problema

En `mass_payment_group_create`, el campo `amount` se setea al bruto de la factura (`-sum(amount_residual)`). El módulo `l10n_ar_tax` aplica las retenciones sumándolas a `payment_total` (sign=+1 para proveedor outbound), lo que deja `payment_total > to_pay_amount`.

Consecuencias:
- La validación de `to_signature_process` falla ("Importe a pagar distinto a Importe de los Pagos").
- Para destrabarla, se elimina la retención manualmente, pero luego no puede volver a cargarse.

En el flujo manual el onchange `_onchange_withholdings` descuenta las retenciones de `amount`, dejando `amount = neto`. En la creación programática ese onchange nunca dispara.

## Solución

Después de crear el payment, se aplica el mismo ajuste que haría `_onchange_withholdings`:

```python
if payment.payment_difference:
    new_amount = payment.amount + payment.payment_difference
    payment.with_context(skip_account_move_synchronization=True).amount = new_amount if new_amount > 0 else 0
```

`payment_difference = to_pay_amount - payment_total = -withholdings_amount`, por lo que `amount` queda en neto y `payment_total == to_pay_amount`.

## Test plan

- [ ] Crear una transacción con facturas de proveedor que apliquen retenciones (posición fiscal con retenciones AR activa).
- [ ] Ejecutar "Alta masiva de OP".
- [ ] Verificar que en las órdenes generadas `payment_total == to_pay_amount` (sin diferencia).
- [ ] Verificar que se puede pasar a "Proceso de Firma" sin ValidationError.
- [ ] Verificar que el monto que muestra la OP es el neto (bruto menos retenciones).
- [ ] Verificar que sin retenciones el comportamiento es idéntico al anterior (sin cambios visibles).