### PR TITLE
[FIX] public_budget: prevent moving child expedient without parent in remit

### DIFF
--- a/public_budget/models/remit.py
+++ b/public_budget/models/remit.py
@@ -145,8 +145,24 @@ class Remit(models.Model):
                     'public_budget.remit') or '/'
         return super().create(vals)
 
+    @api.constrains('expedient_ids')
+    def _check_child_without_parent(self):
+        for rec in self:
+            for expedient in rec.expedient_ids.filtered('parent_id'):
+                if expedient.parent_id not in rec.expedient_ids:
+                    raise ValidationError(_(
+                        'No puede trasladar el expediente hijo "%s" sin incluir '
+                        'su expediente padre "%s" en el remito.')
+                        % (expedient.display_name, expedient.parent_id.display_name))
+
     @api.onchange('expedient_ids')
     def _onchange_expedient_ids(self):
-        if self.expedient_ids and self.expedient_ids.mapped('child_ids'):
-            self.expedient_ids |= self.expedient_ids.mapped('child_ids').filtered(
+        if self.expedient_ids:
+            children = self.expedient_ids.mapped('child_ids').filtered(
                 lambda x: x._origin.current_location_id == self.location_id)
+            if children:
+                self.expedient_ids |= children
+            parents = self.expedient_ids.mapped('parent_id').filtered(
+                lambda x: x._origin.current_location_id == self.location_id)
+            if parents:
+                self.expedient_ids |= parents


### PR DESCRIPTION
## Problem

When adding a child expedient (one with `parent_id`) directly to a remit, the system allowed saving it without including the parent. This violates the business rule that a child expedient can only be moved as part of its parent's transfer.

The existing `_onchange_expedient_ids` already auto-includes children when a parent is added to the remit (correct direction), but there was no server-side constraint enforcing the reverse.

## Changes

**`public_budget/models/remit.py`**

- Added `_check_child_without_parent` (`@api.constrains('expedient_ids')`): raises `ValidationError` if any expedient in the remit has a `parent_id` that is not also in `expedient_ids`. Fires on both create and write.
- Updated `_onchange_expedient_ids`: now also auto-includes the parent when a child is added directly in the UI (symmetric with the existing child auto-include logic). Parent is only auto-added if it shares the same source location.