### PR TITLE
[FIX] public_budget: hide counterpart_currency_amount field in accoun…

### DIFF
--- a/public_budget/views/account_payment_group_views.xml
+++ b/public_budget/views/account_payment_group_views.xml
@@ -313,9 +313,15 @@
             </field> -->
 
             <!-- ocultamos todo lo referente a moneda de contrapartida que no lo usan -->
-            <label for="counterpart_currency_amount" position="replace" />
-            <field name="counterpart_currency_amount" position="replace" />
-            <div name="counterpart_currency_amount" position="replace" />
+            <label for="counterpart_currency_amount" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </label>
+            <field name="counterpart_currency_amount" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </field>
+            <div name="counterpart_currency_amount" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </div>
             <xpath expr="//div[@name='amount_div']//field[@name='currency_id']"
                 position="attributes">
                 <attribute name="invisible">True</attribute>


### PR DESCRIPTION
…t.payment.group form view, but keep in order to be able to inherit it in other modules

task: 69979