### PR TITLE
[FIX] public_budget: to_pay_amount only counts outbound payable lines

### DIFF
--- a/public_budget/models/account_move.py
+++ b/public_budget/models/account_move.py
@@ -84,6 +84,10 @@ class AccountMove(models.Model):
             return self.amount_total
 
         lines = self.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
+        # Only count outbound payable lines (balance < 0 means company owes money to vendor).
+        # Inbound lines (e.g. vendor credit notes collected via inbound payment group) must not
+        # reduce to_pay_amount.
+        lines = lines.filtered(lambda line: line.balance < 0)
         # Add this to allow analysis from date
         to_date = self._context.get('analysis_to_date', False)
         if to_date:


### PR DESCRIPTION
Inbound payable lines (e.g. vendor credit notes collected via an inbound payment group) were incorrectly included in `to_pay_amount`, reducing it when they should have no effect on the outbound commitment amount.

## Root cause

`_get_to_pay_amount_to_date` iterated over all receivable/payable lines of the invoice and checked whether any associated payment group was in an active state (`not in ['draft', 'cancel']`). This included lines with a positive balance (debit on payable account), which represent amounts the vendor owes the company — the opposite direction.

## Fix

Filter lines by `balance < 0` before applying the payment group state check. A negative balance on a payable account means the company owes money to the vendor (outbound commitment). Lines with `balance > 0` represent inbound receivables and must not affect `to_pay_amount`.

This is the V15 equivalent of the fix applied to 18.0 in #620. In V18 the check is done via `payment_type == 'outbound'` on `account.payment`; in V15 `account.payment.group` does not expose `payment_type` at the group level, so the balance direction of the payable line is used as the equivalent signal.

## Post-deploy recompute

Since `to_pay_amount` is stored, after deploying this fix run:

```python
refunds = env['account.move'].search([
    ('transaction_id', '!=', False),
    ('move_type', '=', 'in_refund'),
    ('state', '=', 'posted'),
])
affected = refunds.filtered(
    lambda m: m.payment_group_ids.filtered(
        lambda pg: pg.state not in ['draft', 'cancel']
    )
)
affected._compute_to_pay_amount()
```